### PR TITLE
Split the database into one for user and one for cache.

### DIFF
--- a/tle/__main__.py
+++ b/tle/__main__.py
@@ -64,11 +64,7 @@ def main():
 
     @bot.event
     async def on_ready():
-        if args.nodb:
-            dbfile = None
-        else:
-            dbfile = os.path.join(constants.FILEDIR, constants.DB_FILENAME)
-        await cf_common.initialize(dbfile, constants.CONTEST_CACHE_PERIOD)
+        await cf_common.initialize(args.nodb)
 
     bot.add_listener(discord_common.bot_error_handler, name='on_command_error')
 

--- a/tle/cogs/graphs.py
+++ b/tle/cogs/graphs.py
@@ -235,7 +235,7 @@ class Graphs(commands.Cog):
     @plot.command(brief='Show server rating distribution')
     async def distrib(self, ctx):
         """Plots rating distribution of server members."""
-        res = cf_common.conn.getallhandleswithrating()
+        res = cf_common.user_db.getallhandleswithrating()
         ratings = [rating for _, _, rating in res]
         bin_count = min(len(ratings), 30)
 

--- a/tle/constants.py
+++ b/tle/constants.py
@@ -1,4 +1,4 @@
 FILEDIR = './files'
-DB_FILENAME = 'handles.db'
-CONTEST_CACHE_PERIOD = 3600
+USER_DB_FILENAME = 'user.db'
+CACHE_DB_FILENAME = 'user.db'
 CONTEST_WRITERS_JSON_FILE = 'contest_writers.json'

--- a/tle/constants.py
+++ b/tle/constants.py
@@ -1,4 +1,4 @@
 FILEDIR = './files'
 USER_DB_FILENAME = 'user.db'
-CACHE_DB_FILENAME = 'user.db'
+CACHE_DB_FILENAME = 'cache.db'
 CONTEST_WRITERS_JSON_FILE = 'contest_writers.json'

--- a/tle/util/cache_system.py
+++ b/tle/util/cache_system.py
@@ -6,7 +6,7 @@ import json
 import time
 
 from tle.util import codeforces_api as cf
-from tle.util import handle_conn
+from tle.util import db
 
 logger = logging.getLogger(__name__)
 
@@ -74,7 +74,7 @@ class CacheSystem:
         await self.cache_problems()
 
     def try_disk(self):
-        with suppress(handle_conn.DatabaseDisabledError):
+        with suppress(db.DatabaseDisabledError):
             contests = self.conn.fetch_contests()
             problem_res = self.conn.fetch_problems()
             if not contests or not problem_res:
@@ -102,7 +102,7 @@ class CacheSystem:
         }
         self.contest_last_cache = time.time()
         self.logger.info(f'{len(self.contest_dict)} contests cached')
-        with suppress(handle_conn.DatabaseDisabledError):
+        with suppress(db.DatabaseDisabledError):
             rc = self.conn.cache_contests(contests)
             self.logger.info(f'{rc} contests stored in database')
 
@@ -125,7 +125,7 @@ class CacheSystem:
         }
         self.problems_last_cache = time.time()
         self.logger.info(f'{len(self.problem_dict)} problems cached')
-        with suppress(handle_conn.DatabaseDisabledError):
+        with suppress(db.DatabaseDisabledError):
             rc = self.conn.cache_problems([
                 (
                     prob.name, prob.contestId, prob.index,
@@ -140,7 +140,7 @@ class CacheSystem:
     async def get_rating_solved(self, handle: str, time_out: int):
         cached = self._user_rating_solved(handle)
         stamp, rating, solved = cached
-        with suppress(handle_conn.DatabaseDisabledError):
+        with suppress(db.DatabaseDisabledError):
             if stamp is None:
                 # Try from disk first
                 stamp, rating, solved = await self._retrieve_rating_solved(handle)

--- a/tle/util/cache_system2.py
+++ b/tle/util/cache_system2.py
@@ -8,7 +8,7 @@ import traceback
 
 from tle.util import codeforces_common as cf_common
 from tle.util import codeforces_api as cf
-from tle.util import handle_conn
+from tle.util import db
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +64,7 @@ class ContestCache:
             raise self.reload_exception
 
     async def _try_disk(self):
-        with suppress(handle_conn.DatabaseDisabledError):
+        with suppress(db.DatabaseDisabledError):
             async with self.reload_lock:
                 contests = self.cache_master.conn.fetch_contests()
                 if not contests:
@@ -99,7 +99,7 @@ class ContestCache:
         contests.sort(key=lambda contest: (contest.startTimeSeconds, contest.id))
 
         if from_api:
-            with suppress(handle_conn.DatabaseDisabledError):
+            with suppress(db.DatabaseDisabledError):
                 rc = self.cache_master.conn.cache_contests(contests)
                 self.logger.info(f'{rc} contests stored in database')
 
@@ -172,7 +172,7 @@ class ProblemCache:
             raise self.reload_exception
 
     async def _try_disk(self):
-        with suppress(handle_conn.DatabaseDisabledError):
+        with suppress(db.DatabaseDisabledError):
             async with self.reload_lock:
                 problem_res = self.cache_master.conn.fetch_problems()
                 if not problem_res:
@@ -229,7 +229,7 @@ class ProblemCache:
         self.problem_start = problem_start
         self.problems_last_cache = time.time()
 
-        with suppress(handle_conn.DatabaseDisabledError):
+        with suppress(db.DatabaseDisabledError):
             def get_tuple_repr(problem):
                 return (problem.name,
                         problem.contestId,

--- a/tle/util/db/__init__.py
+++ b/tle/util/db/__init__.py
@@ -1,0 +1,2 @@
+from .cache_db_conn import CacheDbConn
+from .user_db_conn import DummyUserDbConn, UserDbConn, DatabaseDisabledError

--- a/tle/util/db/cache_db_conn.py
+++ b/tle/util/db/cache_db_conn.py
@@ -1,0 +1,128 @@
+import sqlite3
+
+from tle.util import codeforces_api as cf
+
+
+class CacheDbConn:
+    def __init__(self, db_file):
+        self.conn = sqlite3.connect(db_file)
+        self.create_tables()
+
+    def create_tables(self):
+        self.conn.execute(
+            'CREATE TABLE IF NOT EXISTS contest ('
+            'id             INTEGER NOT NULL,'
+            'name           TEXT,'
+            'start_time     INTEGER,'
+            'duration       INTEGER,'
+            'type           TEXT,'
+            'phase          TEXT,'
+            'prepared_by    TEXT,'
+            'PRIMARY KEY (id)'
+            ')'
+        )
+        self.conn.execute(
+            'CREATE TABLE IF NOT EXISTS problem ('
+            'name           TEXT NOT NULL,'
+            'contest_id     INTEGER,'
+            'p_index        TEXT,'
+            'start_time     INTEGER,'
+            'rating         INTEGER,'
+            'type           TEXT,'
+            'tags           TEXT,'
+            'PRIMARY KEY (name)'
+            ')'
+        )
+        self.conn.execute(
+            'CREATE TABLE IF NOT EXISTS rating_change ('
+            'contest_id           INTEGER NOT NULL,'
+            'handle               TEXT NOT NULL,'
+            'rank                 INTEGER,'
+            'rating_update_time   INTEGER,'
+            'old_rating           INTEGER,'
+            'new_rating           INTEGER,'
+            'UNIQUE (contest_id, handle)'
+            ')'
+        )
+        self.conn.execute('CREATE INDEX IF NOT EXISTS ix_rating_change_contest_id '
+                          'ON rating_change (contest_id)')
+        self.conn.execute('CREATE INDEX IF NOT EXISTS ix_rating_change_handle '
+                          'ON rating_change (handle)')
+
+    def fetch_contests(self):
+        query = ('SELECT id, name, start_time, duration, type, phase, prepared_by '
+                 'FROM contest')
+        res = self.conn.execute(query).fetchall()
+        return [cf.Contest._make(contest) for contest in res]
+
+    def fetch_problems(self):
+        query = ('SELECT contest_id, p_index, name, type, rating, tags, start_time '
+                 'FROM problem')
+        res = self.conn.execute(query).fetchall()
+        return [(cf.Problem._make(problem[:6]), problem[6]) for problem in res]
+
+    def cache_contests(self, contests):
+        query = ('INSERT OR REPLACE INTO contest '
+                 '(id, name, start_time, duration, type, phase, prepared_by) '
+                 'VALUES (?, ?, ?, ?, ?, ?, ?)')
+        rc = self.conn.executemany(query, contests).rowcount
+        self.conn.commit()
+        return rc
+
+    def cache_problems(self, problems):
+        query = ('INSERT OR REPLACE INTO problem '
+                 '(name, contest_id, p_index, start_time, rating, type, tags) '
+                 'VALUES (?, ?, ?, ?, ?, ?, ?)')
+        rc = self.conn.executemany(query, problems).rowcount
+        self.conn.commit()
+        return rc
+
+    def save_rating_changes(self, changes):
+        change_tuples = [(change.contestId,
+                          change.handle,
+                          change.rank,
+                          change.ratingUpdateTimeSeconds,
+                          change.oldRating,
+                          change.newRating) for change in changes]
+        query = ('INSERT OR REPLACE INTO rating_change '
+                 '(contest_id, handle, rank, rating_update_time, old_rating, new_rating) '
+                 'VALUES (?, ?, ?, ?, ?, ?)')
+        rc = self.conn.executemany(query, change_tuples).rowcount
+        self.conn.commit()
+        return rc
+
+    def get_all_rating_changes(self):
+        query = ('SELECT contest_id, name, handle, rank, rating_update_time, old_rating, new_rating '
+                 'FROM rating_change r '
+                 'LEFT JOIN contest c '
+                 'ON r.contest_id = c.id')
+        res = self.conn.execute(query).fetchall()
+        return [cf.RatingChange._make(change) for change in res]
+
+    def get_rating_changes_for_contest(self, contest_id):
+        query = ('SELECT contest_id, name, handle, rank, rating_update_time, old_rating, new_rating '
+                 'FROM rating_change r '
+                 'LEFT JOIN contest c '
+                 'ON r.contest_id = c.id '
+                 'WHERE r.contest_id = ?')
+        res = self.conn.execute(query, (contest_id,)).fetchall()
+        return [cf.RatingChange._make(change) for change in res]
+
+    def has_rating_changes_saved(self, contest_id):
+        query = ('SELECT contest_id '
+                 'FROM rating_change '
+                 'WHERE contest_id = ?')
+        res = self.conn.execute(query, (contest_id,)).fetchone()
+        return res is not None
+
+    def get_rating_changes_for_handle(self, handle):
+        query = ('SELECT contest_id, name, handle, rank, rating_update_time, old_rating, new_rating '
+                 'FROM rating_change r '
+                 'LEFT JOIN contest c '
+                 'ON r.contest_id = c.id '
+                 'WHERE r.handle = ?')
+        res = self.conn.execute(query, (handle,)).fetchall()
+        return [cf.RatingChange._make(change) for change in res]
+
+    def close(self):
+        self.conn.close()

--- a/tle/util/db/user_db_conn.py
+++ b/tle/util/db/user_db_conn.py
@@ -10,12 +10,12 @@ class DatabaseDisabledError(commands.CommandError):
     pass
 
 
-class DummyConn:
+class DummyUserDbConn:
     def __getattribute__(self, item):
         raise DatabaseDisabledError
 
 
-class HandleConn:
+class UserDbConn:
     def __init__(self, dbfile):
         self.conn = sqlite3.connect(dbfile)
         self.create_tables()
@@ -96,21 +96,6 @@ class HandleConn:
                 before TEXT
             )
         ''')
-        self.conn.execute('''
-            CREATE TABLE IF NOT EXISTS rating_changes(
-                contest_id           INTEGER NOT NULL,
-                handle               TEXT NOT NULL,
-                rank                 INTEGER,
-                rating_update_time   INTEGER,
-                old_rating           INTEGER,
-                new_rating           INTEGER,
-                UNIQUE (contest_id, handle)
-            )
-        ''')
-        self.conn.execute(
-            'CREATE INDEX IF NOT EXISTS ix_rating_changes_contest_id ON rating_changes (contest_id)')
-        self.conn.execute(
-            'CREATE INDEX IF NOT EXISTS ix_rating_changes_handle ON rating_changes (handle)')
 
     def fetch_contests(self):
         query = 'SELECT id, name, start_time, duration, type, phase, prepared_by FROM contest'
@@ -366,54 +351,6 @@ class HandleConn:
         query = '''DELETE FROM reminder WHERE guild_id = ?'''
         self.conn.execute(query, (guild_id,))
         self.conn.commit()
-
-    def save_rating_changes(self, changes):
-        change_tuples = [(change.contestId,
-                          change.handle,
-                          change.rank,
-                          change.ratingUpdateTimeSeconds,
-                          change.oldRating,
-                          change.newRating) for change in changes]
-        return self._insert_many('rating_changes',
-                                 'contest_id handle rank rating_update_time old_rating new_rating'.split(),
-                                 change_tuples)
-
-    def get_all_rating_changes(self):
-        query = '''
-        SELECT contest_id, name, handle, rank, rating_update_time, old_rating, new_rating
-        FROM rating_changes r
-        LEFT JOIN contest c
-        ON r.contest_id = c.id
-        '''
-        res = self.conn.execute(query).fetchall()
-        return [cf.RatingChange._make(change) for change in res]
-
-    def get_rating_changes_for_contest(self, contest_id):
-        query = '''
-        SELECT contest_id, name, handle, rank, rating_update_time, old_rating, new_rating
-        FROM rating_changes r
-        LEFT JOIN contest c
-        ON r.contest_id = c.id
-        WHERE r.contest_id = ?
-        '''
-        res = self.conn.execute(query, (contest_id,)).fetchall()
-        return [cf.RatingChange._make(change) for change in res]
-
-    def has_rating_changes_saved(self, contest_id):
-        query = 'SELECT contest_id FROM rating_changes WHERE contest_id = ?'
-        res = self.conn.execute(query, (contest_id,)).fetchone()
-        return res is not None
-
-    def get_rating_changes_for_handle(self, handle):
-        query = '''
-        SELECT contest_id, name, handle, rank, rating_update_time, old_rating, new_rating
-        FROM rating_changes r
-        LEFT JOIN contest c
-        ON r.contest_id = c.id
-        WHERE r.handle = ?
-        '''
-        res = self.conn.execute(query, (handle,)).fetchall()
-        return [cf.RatingChange._make(change) for change in res]
 
     def close(self):
         self.conn.close()

--- a/tle/util/discord_common.py
+++ b/tle/util/discord_common.py
@@ -4,7 +4,7 @@ import random
 import discord
 from discord.ext import commands
 
-from tle.util import handle_conn
+from tle.util import db
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +42,7 @@ async def bot_error_handler(ctx, exception):
         # Errors already handled in cogs should have .handled = True
         return
 
-    if isinstance(exception, handle_conn.DatabaseDisabledError):
+    if isinstance(exception, db.DatabaseDisabledError):
         await ctx.send(embed=embed_alert('Sorry, the database is not available. Some features are disabled.'))
     elif isinstance(exception, commands.NoPrivateMessage):
         await ctx.send(embed=embed_alert('Commands are disabled in private channels'))


### PR DESCRIPTION
### Changes
- The file `user.db` is used in place of `handles.db` and `cache.db` is the new database file to be used by cache2.
- Two different connections classes `UserDbConn` and `CacheDbConn` are used for the two databases.
- Currently the old cache uses `user.db`, which will be discontinued soon.