### PR TITLE
Ranklist for old contests

### DIFF
--- a/tle/cogs/contests.py
+++ b/tle/cogs/contests.py
@@ -398,6 +398,8 @@ class Contests(commands.Cog):
             ranklist = cf_common.cache2.ranklist_cache.get_ranklist(contest)
             deltas_status = 'Predicted'
         except cache_system2.RanklistNotMonitored:
+            if contest.phase == 'BEFORE':
+                raise ContestCogError(f'Contest `{contest.id} | {contest.name}` has not started')
             wait_msg = await ctx.send('Please wait...')
             ranklist = await cf_common.cache2.ranklist_cache.generate_ranklist(contest.id,
                                                                                fetch_changes=True)
@@ -435,7 +437,7 @@ class Contests(commands.Cog):
         pages = self._make_standings_pages(contest, problem_indices, handle_standings, deltas)
 
         embed = discord_common.cf_color_embed(title=contest.name, url=contest.url)
-        phase = contest.phase.lower().capitalize().replace('_', ' ')
+        phase = contest.phase.capitalize().replace('_', ' ')
         embed.add_field(name='Phase', value=phase)
         if ranklist.is_rated:
             embed.add_field(name='Deltas', value=deltas_status)

--- a/tle/util/cache_system2.py
+++ b/tle/util/cache_system2.py
@@ -471,14 +471,17 @@ class RanklistCache:
         if fetch_changes:
             # Fetch final rating changes from CF.
             # For older contests.
+            is_rated = False
             try:
                 changes = await cf.contest.ratingChanges(contest_id=contest_id)
+                # For contests intended to be rated but declared unrated, an empty list is returned.
+                is_rated = len(changes) > 0
             except cf.RatingChangesUnavailableError:
-                ranklist = Ranklist(contest, problems, standings, now, is_rated=False)
-            else:
+                pass
+            ranklist = Ranklist(contest, problems, standings, now, is_rated=is_rated)
+            if is_rated:
                 delta_by_handle = {change.handle: change.newRating - change.oldRating
                                    for change in changes}
-                ranklist = Ranklist(contest, problems, standings, now, is_rated=True)
                 ranklist.set_deltas(delta_by_handle)
         elif predict_changes:
             # Rating changes have not been applied yet, predict rating changes.

--- a/tle/util/ranklist/ranklist.py
+++ b/tle/util/ranklist/ranklist.py
@@ -4,43 +4,52 @@ from tle.util.ranklist.rating_calculator import CodeforcesRatingCalculator
 
 
 class RanklistError(commands.CommandError):
-    pass
+    def __init__(self, contest, message=None):
+        if message is not None:
+            super().__init__(message)
+        self.contest = contest
 
 
 class ContestNotRatedError(RanklistError):
     def __init__(self, contest):
-        super().__init__(f'`{contest.name}` is not rated')
-        self.contest = contest
+        super().__init__(contest, f'`{contest.name}` is not rated')
 
 
 class HandleNotPresentError(RanklistError):
     def __init__(self, contest, handle):
-        super().__init__(f'Handle `{handle}`` not present in standings of `{contest.name}`')
-        self.contest = contest
+        super().__init__(contest, f'Handle `{handle}`` not present in standings of `{contest.name}`')
         self.handle = handle
 
 
+class DeltasNotPresentError(RanklistError):
+    def __init__(self, contest):
+        super().__init__(contest, f'Rating changes for `{contest.name}` not calculated or set.')
+
+
 class Ranklist:
-    def __init__(self, contest, problems, standings, fetch_time, current_rating=None):
+    def __init__(self, contest, problems, standings, fetch_time, *, is_rated):
         self.contest = contest
         self.problems = problems
         self.standings = standings
         self.fetch_time = fetch_time
 
-        # current_rating is a mapping from handle to rating for the handles
-        # for whom the contest is rated.
-        self.is_rated = current_rating is not None
+        self.is_rated = is_rated
 
-        self.delta_by_handle = {}
         self.standing_by_id = {}
         for row in self.standings:
             id_ = row.party.teamId or row.party.members[0].handle
             self.standing_by_id[id_] = row
 
-        if self.is_rated:
-            self._prepare_predictions(current_rating)
+        self.delta_by_handle = None
 
-    def _prepare_predictions(self, current_rating):
+    def set_deltas(self, delta_by_handle):
+        if not self.is_rated:
+            raise ContestNotRatedError(self.contest)
+        self.delta_by_handle = delta_by_handle.copy()
+
+    def predict(self, current_rating):
+        if not self.is_rated:
+            raise ContestNotRatedError(self.contest)
         standings = [(id_, row.points, row.penalty, current_rating[id_])
                      for id_, row in self.standing_by_id.items() if id_ in current_rating]
         if standings:


### PR DESCRIPTION
Ranklist support for older finished contests.

Closes #42 

### Changes
- Minor changes to `Ranklist`.
- Changes to `RanklistCache` regarding ranklist generation.
- Command `future` replaced by `clist` group with subcommands `future`, `active`, and `finished`.
- Unused timezone feature removed.

### Screenshot

![screenshot](https://i.imgur.com/h1IoqpG.png)