### PR TITLE
Improved Codeforces API error handling

### DIFF
--- a/tle/cogs/codeforces.py
+++ b/tle/cogs/codeforces.py
@@ -36,8 +36,7 @@ class Codeforces(commands.Cog):
         handle = handles[0]
         user = cf_common.user_db.fetch_cfuser(handle)
         rating = user.rating
-        resp = await cf_common.run_handle_related_coro(handles, cf.user.status)
-        submissions = resp[0]
+        submissions = await cf.user.status(handle=handle)
         solved = {sub.problem.name for sub in submissions}
 
         lower = bounds[0] if len(bounds) > 0 else None
@@ -93,8 +92,7 @@ class Codeforces(commands.Cog):
 
         user = cf_common.user_db.fetch_cfuser(handle)
         rating = user.rating
-        resp = await cf_common.run_handle_related_coro(handles, cf.user.status)
-        submissions = resp[0]
+        submissions = await cf.user.status(handle=handle)
         solved = {sub.problem.name for sub in submissions}
 
         delta = round(delta, -2)
@@ -146,8 +144,7 @@ class Codeforces(commands.Cog):
             await ctx.send(f'You do not have an active challenge')
             return
 
-        resp = await cf_common.run_handle_related_coro(handles, cf.user.status)
-        submissions = resp[0]
+        submissions = await cf.user.status(handle=handle)
         solved = {sub.problem.name for sub in submissions if sub.verdict == 'OK'}
 
         challenge_id, issue_time, name, contestId, index, delta = active
@@ -196,7 +193,7 @@ class Codeforces(commands.Cog):
         """Recommends a contest based on Codeforces rating of the handle provided."""
         handles = handles or ('!' + str(ctx.author),)
         handles = await cf_common.resolve_handles(ctx, self.converter, handles)
-        resp = await cf_common.run_handle_related_coro(handles, cf.user.status)
+        resp = [await cf.user.status(handle=handle) for handle in handles]
 
         user_submissions = resp
         try:
@@ -228,8 +225,7 @@ class Codeforces(commands.Cog):
             await ctx.send(f'Recommended contest for `{str_handles}`', embed=embed)
 
     async def cog_command_error(self, ctx, error):
-        await cf_common.cf_handle_error_handler(ctx, error)
-        await cf_common.run_handle_coro_error_handler(ctx, error)
+        await cf_common.resolve_handle_error_handler(ctx, error)
 
 
 def setup(bot):

--- a/tle/cogs/contests.py
+++ b/tle/cogs/contests.py
@@ -449,7 +449,7 @@ class Contests(commands.Cog):
             await ctx.send(embed=discord_common.embed_alert(error))
             error.handled = True
             return
-        await cf_common.cf_handle_error_handler(ctx, error)
+        await cf_common.resolve_handle_error_handler(ctx, error)
 
 
 def setup(bot):

--- a/tle/cogs/handles.py
+++ b/tle/cogs/handles.py
@@ -128,11 +128,8 @@ class Handles(commands.Cog):
     @commands.has_role('Admin')
     async def sethandle(self, ctx, member: discord.Member, handle: str):
         """Set Codeforces handle of a user"""
-        try:
-            users = await cf.user.info(handles=[handle])
-            user = users[0]
-        except cf.CodeforcesApiError as er:
-            raise cf_common.RunHandleCoroFailedError(handle, er) from er
+        users = await cf.user.info(handles=[handle])
+        user = users[0]
 
         # CF API returns correct handle ignoring case, update to it
         handle = user.handle
@@ -324,7 +321,7 @@ class Handles(commands.Cog):
         await ctx.send(msg)
 
     async def cog_command_error(self, ctx, error):
-        await cf_common.run_handle_coro_error_handler(ctx, error)
+        pass
 
 
 def setup(bot):

--- a/tle/util/discord_common.py
+++ b/tle/util/discord_common.py
@@ -4,6 +4,7 @@ import random
 import discord
 from discord.ext import commands
 
+from tle.util import codeforces_api as cf
 from tle.util import db
 
 logger = logging.getLogger(__name__)
@@ -48,6 +49,8 @@ async def bot_error_handler(ctx, exception):
         await ctx.send(embed=embed_alert('Commands are disabled in private channels'))
     elif isinstance(exception, commands.DisabledCommand):
         await ctx.send(embed=embed_alert('Sorry, this command is temporarily disabled'))
+    elif isinstance(exception, cf.CodeforcesApiError):
+        await ctx.send(embed=embed_alert(exception))
     else:
         exc_info = type(exception), exception, exception.__traceback__
         logger.exception('Ignoring exception in command {}:'.format(ctx.command), exc_info=exc_info)


### PR DESCRIPTION
Improved Codeforces API error handling.

- Discarded the poor `run_handle_related_coro` mechanism.
- More specific errors are now raised by the API methods which are handled in the bot's error handler.

Closes #61 