### PR TITLE
Add support for user_guard error

### DIFF
--- a/tle/cogs/handles.py
+++ b/tle/cogs/handles.py
@@ -169,7 +169,8 @@ class Handles(commands.Cog):
         await self.update_member_rank_role(member, roles[0])
 
     @handle.command(brief='Identify yourself', usage='[handle]')
-    @cf_common.user_guard(group='handle')
+    @cf_common.user_guard(group='handle',
+                          get_exception=lambda: HandleCogError('Identification is already running for you'))
     async def identify(self, ctx, handle: str):
         """Link a codeforces account to discord account by submitting a compile error to a random problem"""
         users = await cf.user.info(handles=[handle])

--- a/tle/util/codeforces_common.py
+++ b/tle/util/codeforces_common.py
@@ -69,7 +69,7 @@ async def initialize(nodb):
 
 
 # algmyr's guard idea:
-def user_guard(*, group):
+def user_guard(*, group, get_exception=None):
     active = active_groups[group]
 
     def guard(fun):
@@ -78,6 +78,8 @@ def user_guard(*, group):
             user = ctx.message.author.id
             if user in active:
                 logger.info(f'{user} repeatedly calls {group} group')
+                if get_exception is not None:
+                    raise get_exception()
                 return
             active.add(user)
             try:


### PR DESCRIPTION
user_guard raises the optionally provided exception when the group is active.

This is not a great system but better than silently ignoring.