### PR TITLE
prettyhandles: spacing and minor improvements

### DIFF
--- a/tle/cogs/handles.py
+++ b/tle/cogs/handles.py
@@ -67,10 +67,10 @@ def get_prettyhandles_image(rankings):
     y += int(y_inc * 1.5)
     for pos, name, handle, rating in rankings:
         if len(name) > 17:
-            name = name[:14] + "..."
+            name = name[:16] + "…"
         if len(handle) > 17:
-            handle = handle[:14] + "..."
-        s = f"{f'#{pos}':<4}{name:<18}{handle:<18}{rating:>6}"
+            handle = handle[:16] + "…"
+        s = f"{pos:<4}{name:<18}{handle:<18}{rating:>6}"
 
         color = rating_to_color(rating)
         if rating!='N/A' and rating >= 3000:  # nutella


### PR DESCRIPTION
Leaves enough room for three digits. We're now safe until we cross 999 users. I removed the leading # to make room for that space, it felt pretty weird anyway.

Additionally, changed `...` into the character `…` so we can fit more letters on screen.

Fixes the issue #125 was meant to fix, but somehow there was a force push that killed that pr. :/