### PR TITLE
Shiny new way to do repeating tasks!

### DIFF
--- a/tle/cogs/contests.py
+++ b/tle/cogs/contests.py
@@ -104,10 +104,10 @@ class Contests(commands.Cog):
 
     @commands.Cog.listener()
     async def on_ready(self):
-        self._update_task.start(self)
+        self._update_task.start()
 
-    @tasks.task(name='ContestCogUpdate',
-                waiter=tasks.Waiter.for_event('EVENT_CONTEST_LIST_REFRESH'))
+    @tasks.task_spec(name='ContestCogUpdate',
+                     waiter=tasks.Waiter.for_event('EVENT_CONTEST_LIST_REFRESH'))
     async def _update_task(self, _):
         contest_cache = cf_common.cache2.contest_cache
         self.future_contests = contest_cache.get_contests_in_phase('BEFORE')

--- a/tle/cogs/contests.py
+++ b/tle/cogs/contests.py
@@ -17,6 +17,7 @@ from tle.util import discord_common
 from tle.util import paginator
 from tle.util import ranklist as rl
 from tle.util import table
+from tle.util import tasks
 
 _CONTESTS_PER_PAGE = 5
 _CONTEST_PAGINATE_WAIT_TIME = 5 * 60
@@ -103,18 +104,11 @@ class Contests(commands.Cog):
 
     @commands.Cog.listener()
     async def on_ready(self):
-        asyncio.create_task(self._updater_task())
+        self._update_task.start(self)
 
-    async def _updater_task(self):
-        self.logger.info('Running Contests cog updater task')
-        while True:
-            try:
-                await cf_common.event_sys.wait_for('EVENT_CONTEST_LIST_REFRESH')
-                await self._reload()
-            except Exception:
-                self.logger.warning(f'Exception in Contests cog updater task, ignoring.', exc_info=True)
-
-    async def _reload(self):
+    @tasks.task(name='ContestCogUpdate',
+                waiter=tasks.Waiter.for_event('EVENT_CONTEST_LIST_REFRESH'))
+    async def _update_task(self, _):
         contest_cache = cf_common.cache2.contest_cache
         self.future_contests = contest_cache.get_contests_in_phase('BEFORE')
         self.active_contests = (contest_cache.get_contests_in_phase('CODING') +

--- a/tle/util/cache_system2.py
+++ b/tle/util/cache_system2.py
@@ -6,6 +6,7 @@ from discord.ext import commands
 
 from tle.util import codeforces_common as cf_common
 from tle.util import codeforces_api as cf
+from tle.util import tasks
 from tle.util.ranklist import Ranklist
 
 logger = logging.getLogger(__name__)
@@ -44,12 +45,13 @@ class ContestCache:
 
         self.reload_lock = asyncio.Lock()
         self.reload_exception = None
+        self.next_delay = None
 
         self.logger = logging.getLogger(self.__class__.__name__)
 
     async def run(self):
         await self._try_disk()
-        asyncio.create_task(self._contest_updater_task())
+        self._update_task.start(self)
 
     async def reload_now(self):
         """Force a reload. If currently reloading it will wait until done."""
@@ -60,7 +62,7 @@ class ContestCache:
             async with self.reload_lock:
                 pass
         else:
-            await self._pre_reload()
+            await self._update_task.manual_trigger(self)
 
         if self.reload_exception:
             raise self.reload_exception
@@ -85,22 +87,20 @@ class ContestCache:
                 return
             await self._update(contests, from_api=False)
 
-    async def _contest_updater_task(self):
-        self.logger.info('Running contest updater task')
-        while True:
-            delay = await self._pre_reload()
-            await asyncio.sleep(delay)
+    @tasks.task(name='ContestCacheUpdate')
+    async def _update_task(self, _):
+        async with self.reload_lock:
+            self.next_delay = await self._reload_contests()
+        self.reload_exception = None
 
-    async def _pre_reload(self):
-        try:
-            async with self.reload_lock:
-                delay = await self._reload_contests()
-            self.reload_exception = None
-        except Exception as ex:
-            self.reload_exception = ex
-            self.logger.warning('Exception in contest updater task, ignoring.', exc_info=True)
-            delay = self._EXCEPTION_CONTEST_RELOAD_DELAY
-        return delay
+    @_update_task.waiter()
+    async def _update_task_waiter(self):
+        await asyncio.sleep(self.next_delay)
+
+    @_update_task.exception_handler()
+    async def _update_task_exception_handler(self, ex):
+        self.reload_exception = ex
+        self.next_delay = self._EXCEPTION_CONTEST_RELOAD_DELAY
 
     async def _reload_contests(self):
         contests = await cf.contest.list()
@@ -176,7 +176,7 @@ class ProblemCache:
 
     async def run(self):
         await self._try_disk()
-        asyncio.create_task(self._problem_updater_task())
+        self._update_task.start(self)
 
     async def reload_now(self):
         """Force a reload. If currently reloading it will wait until done."""
@@ -187,7 +187,7 @@ class ProblemCache:
             async with self.reload_lock:
                 pass
         else:
-            await self._pre_reload()
+            await self._update_task.manual_trigger(self)
 
         if self.reload_exception:
             raise self.reload_exception
@@ -202,20 +202,16 @@ class ProblemCache:
             self.problem_by_name = {problem.name: problem for problem in problems}
             self.logger.info(f'{len(self.problems)} problems fetched from disk')
 
-    async def _problem_updater_task(self):
-        self.logger.info('Running problem updater task')
-        while True:
-            await self._pre_reload()
-            await asyncio.sleep(self._RELOAD_INTERVAL)
+    @tasks.task(name='ProblemCacheUpdate',
+                waiter=tasks.Waiter.constant_delay(_RELOAD_INTERVAL))
+    async def _update_task(self, _):
+        async with self.reload_lock:
+            await self._reload_problems()
+        self.reload_exception = None
 
-    async def _pre_reload(self):
-        try:
-            async with self.reload_lock:
-                await self._reload_problems()
-            self.reload_exception = None
-        except Exception as ex:
-            self.reload_exception = ex
-            self.logger.warning('Exception in problem updater task, ignoring.', exc_info=True)
+    @_update_task.exception_handler()
+    async def _update_task_exception_handler(self, ex):
+        self.reload_exception = ex
 
     async def _reload_problems(self):
         problems, _ = await cf.problemset.problems()
@@ -254,17 +250,13 @@ class RatingChangesCache:
 
     def __init__(self, cache_master):
         self.cache_master = cache_master
-
         self.monitored_contests = []
-
         self.handle_rating_cache = {}
-        self.update_task = None
-
         self.logger = logging.getLogger(self.__class__.__name__)
 
     async def run(self):
         self._refresh_handle_cache()
-        asyncio.create_task(self._rating_changes_updater_task())
+        self._update_task.start(self)
 
     async def fetch_contest(self, contest_id):
         """Fetch rating changes for a particular contest. Intended for manual trigger."""
@@ -291,22 +283,15 @@ class RatingChangesCache:
         self._save_changes(changes)
         return len(changes)
 
-    async def _rating_changes_updater_task(self):
-        self.logger.info('Running rating changes updater task')
-        while True:
-            try:
-                await cf_common.event_sys.wait_for('EVENT_CONTEST_LIST_REFRESH')
-                await self._process_contests()
-            except Exception:
-                self.logger.warning(f'Exception in rating changes updater task, ignoring.', exc_info=True)
-
     def is_newly_finished_without_rating_changes(self, contest):
         now = time.time()
         return (contest.phase == 'FINISHED' and
                 now - contest.end_time < self._RATED_DELAY and
                 not self.has_rating_changes_saved(contest.id))
 
-    async def _process_contests(self):
+    @tasks.task(name='RatingChangesCacheUpdate',
+                waiter=tasks.Waiter.for_event('EVENT_CONTEST_LIST_REFRESH'))
+    async def _update_task(self, _):
         # Some notes:
         # A hack phase is tagged as FINISHED with empty list of rating changes. After the hack
         # phase, the phase changes to systest then again FINISHED. Since we cannot differentiate
@@ -319,30 +304,25 @@ class RatingChangesCache:
         cur_ids = {contest.id for contest in self.monitored_contests}
         new_ids = {contest.id for contest in to_monitor}
         if new_ids != cur_ids:
-            if self.update_task:
-                self.update_task.cancel()
+            self._monitor_task.stop()
             if to_monitor:
-                self.update_task = asyncio.create_task(self._update_task(to_monitor))
+                self.monitored_contests = to_monitor
+                self._monitor_task.start(self)
             else:
                 self.monitored_contests = []
 
-    async def _update_task(self, contests):
-        self.monitored_contests = contests
-        while True:
-            self.monitored_contests = [contest for contest in self.monitored_contests
-                                       if self.is_newly_finished_without_rating_changes(contest)]
-            if not self.monitored_contests:
-                break
-            try:
-                all_changes = await self._fetch(contests)
-            except Exception:
-                self.logger.warning(f'Exception in rating change update task 2, ignoring.', exc_info=True)
-            else:
-                self._save_changes(all_changes)
-            await asyncio.sleep(self._RELOAD_DELAY)
-        self.monitored_contests = []
-        self.logger.info('Rated changes fetched for contests that were being monitored, '
-                         'halting update task.')
+    @tasks.task(name='RatingChangesCacheUpdate.MonitorNewlyFinishedContests',
+                waiter=tasks.Waiter.constant_delay(_RELOAD_DELAY))
+    async def _monitor_task(self, _):
+        self.monitored_contests = [contest for contest in self.monitored_contests
+                                   if self.is_newly_finished_without_rating_changes(contest)]
+        if not self.monitored_contests:
+            self.logger.info('Rated changes fetched for contests that were being monitored.')
+            self._monitor_task.stop()
+            return
+
+        all_changes = await self._fetch(self.monitored_contests)
+        self._save_changes(all_changes)
 
     async def _fetch(self, contests):
         all_changes = []
@@ -412,14 +392,13 @@ class RanklistCache:
 
     def __init__(self, cache_master):
         self.cache_master = cache_master
-
+        self.monitored_contests = []
         self.ranklist_by_contest = {}
-        self.update_task = None
 
         self.logger = logging.getLogger(self.__class__.__name__)
 
     async def run(self):
-        asyncio.create_task(self._ranklist_updater_task())
+        self._update_task.start(self)
 
     def get_ranklist(self, contest):
         try:
@@ -427,49 +406,38 @@ class RanklistCache:
         except KeyError:
             raise RanklistNotMonitored(contest)
 
-    async def _ranklist_updater_task(self):
-        self.logger.info('Running ranklist updater task')
-        while True:
-            try:
-                await cf_common.event_sys.wait_for('EVENT_CONTEST_LIST_REFRESH')
-                await self._process_contests()
-            except Exception:
-                self.logger.warning('Exception in ranklist updater task, ignoring.', exc_info=True)
-
-    async def _process_contests(self):
+    @tasks.task(name='RanklistCacheUpdate',
+                waiter=tasks.Waiter.for_event('EVENT_CONTEST_LIST_REFRESH'))
+    async def _update_task(self, _):
         contests_by_phase = self.cache_master.contest_cache.contests_by_phase
         running_contests = contests_by_phase['_RUNNING']
         check = self.cache_master.rating_changes_cache.is_newly_finished_without_rating_changes
         to_monitor = running_contests + list(filter(check, contests_by_phase['FINISHED']))
         new_ids = {contest.id for contest in to_monitor}
         if new_ids != self.ranklist_by_contest.keys():
-            if self.update_task:
-                self.update_task.cancel()
+            self._monitor_task.stop()
             if to_monitor:
-                self.update_task = asyncio.create_task(self._update_task(to_monitor))
+                self.monitored_contests = to_monitor
+                self._monitor_task.start(self)
             else:
                 self.ranklist_by_contest = {}
 
-    async def _update_task(self, contests):
+    @tasks.task(name='RanklistCacheUpdate.MonitorActiveContests',
+                waiter=tasks.Waiter.constant_delay(_RELOAD_DELAY))
+    async def _monitor_task(self, _):
         check = self.cache_master.rating_changes_cache.is_newly_finished_without_rating_changes
-        while True:
-            contests = [contest for contest in contests
-                        if contest.phase != 'FINISHED' or check(contest)]
-            if not contests:
-                break
-            try:
-                ranklist_by_contest = await self._fetch(contests)
-            except Exception:
-                self.logger.warning(f'Exception in ranklist update task 2, ignoring.', exc_info=True)
-            else:
-                for contest in contests:
-                    # Keep previous ranklist (if exists) in case fetch failed
-                    if contest.id in self.ranklist_by_contest and contest.id not in ranklist_by_contest:
-                        ranklist_by_contest[contest.id] = self.ranklist_by_contest[contest.id]
-                self.ranklist_by_contest = ranklist_by_contest
-            await asyncio.sleep(self._RELOAD_DELAY)
-        self.ranklist_by_contest = {}
-        self.logger.info('Halting ranklist monitor task')
+        self.monitored_contests = [contest for contest in self.monitored_contests
+                                   if contest.phase != 'FINISHED' or check(contest)]
+        if not self.monitored_contests:
+            self.ranklist_by_contest = {}
+            self.logger.info('No more active contests for which to monitor ranklists.')
+            self._monitor_task.stop()
+            return
+
+        ranklist_by_contest = await self._fetch(self.monitored_contests)
+        # If any ranklist could not be fetched, the old ranklist is kept.
+        for contest_id, ranklist in ranklist_by_contest.items():
+            self.ranklist_by_contest[contest_id] = ranklist
 
     async def generate_ranklist(self, contest_id, *, fetch_changes=False, predict_changes=False):
         assert fetch_changes ^ predict_changes

--- a/tle/util/tasks.py
+++ b/tle/util/tasks.py
@@ -17,147 +17,211 @@ class WaiterRequired(TaskError):
 
 class TaskAlreadyRunning(TaskError):
     def __init__(self, name):
-        super().__init__(f'Task `{name}` is already running')
+        super().__init__(f'Attempt to start task `{name}` which is already running')
+
+
+def _ensure_coroutine_func(func):
+    if not asyncio.iscoroutinefunction(func):
+        raise TypeError('The decorated function must be a coroutine function.')
 
 
 class Waiter:
-    def __init__(self, coro, *, run_first=False, needs_self=True):
-        """`run_first` denotes whether this waiter should be run before the task's `coro` when
-        run for the first time. `needs_self` indicates whether a self argument is required by
-        the `coro`.
+    def __init__(self, func, *, run_first=False, needs_instance=False):
+        """`run_first` denotes whether this waiter should be run before the task's `func` when
+        run for the first time. `needs_instance` indicates whether a self argument is required by
+        the `func`.
         """
-        self.coro = coro
+        _ensure_coroutine_func(func)
+        self.func = func
         self.run_first = run_first
-        self.needs_self = needs_self
+        self.needs_instance = needs_instance
 
-    async def wait(self, self_arg=None):
-        if self.needs_self:
-            return await self.coro(self_arg)
+    async def wait(self, instance=None):
+        if self.needs_instance:
+            return await self.func(instance)
         else:
-            return await self.coro()
+            return await self.func()
 
     @staticmethod
-    def constant_delay(delay, run_first=False):
+    def fixed_delay(delay, run_first=False):
         """Returns a waiter that always waits for the given time (in seconds) and returns the
         time waited.
         """
-        async def wait_coro():
+
+        async def wait_func():
             await asyncio.sleep(delay)
             return delay
-        return Waiter(wait_coro, run_first=run_first, needs_self=False)
+
+        return Waiter(wait_func, run_first=run_first)
 
     @staticmethod
     def for_event(event, run_first=True):
         """Returns a waiter that waits for the given event and returns the result of that
         event.
         """
-        async def wait_coro():
+
+        async def wait_func():
             return await cf_common.event_sys.wait_for(event)
-        return Waiter(wait_coro, run_first=run_first, needs_self=False)
+
+        return Waiter(wait_func, run_first=run_first)
 
 
 class ExceptionHandler:
-    def __init__(self, coro, *, needs_self=True):
-        """`needs_self` indicates whether a self argument is required by the `coro`."""
-        self.coro = coro
-        self.needs_self = needs_self
+    def __init__(self, func, *, needs_instance=False):
+        """`needs_instance` indicates whether a self argument is required by the `func`."""
+        _ensure_coroutine_func(func)
+        self.func = func
+        self.needs_instance = needs_instance
 
-    async def handle(self, exception, self_arg=None):
-        if self.needs_self:
-            await self.coro(self_arg, exception)
+    async def handle(self, exception, instance=None):
+        if self.needs_instance:
+            await self.func(instance, exception)
         else:
-            await self.coro(exception)
+            await self.func(exception)
 
 
 class Task:
-    """A task that repeats until stopped. A task must have a name, a coroutine `coro` to execute
-    periodically and another coroutine `waiter` to wait on between calls to `coro`. The return
-    value of `waiter` is passed to `coro` in the next call. An optional coroutine
-    `exception_handler` may be provided to which exceptions will be reported.
+    """A task that repeats until stopped. A task must have a name, a coroutine function `func` to
+    execute periodically and another coroutine function `waiter` to wait on between calls to `func`.
+     The return value of `waiter` is passed to `func` in the next call. An optional coroutine
+    function `exception_handler` may be provided to which exceptions will be reported.
     """
 
-    def __init__(self, name, coro, waiter, exception_handler=None, *, needs_self=True):
-        """`needs_self` indicates whether a self argument is required by the `coro`."""
+    def __init__(self, name, func, waiter, exception_handler=None, *, instance=None):
+        """`instance`, if present, is passed as the first argument to `func`."""
+        _ensure_coroutine_func(func)
         self.name = name
-        self.coro = coro
+        self.func = func
         self._waiter = waiter
         self._exception_handler = exception_handler
-        self.needs_self = needs_self
+        self.instance = instance
         self.asyncio_task = None
         self.logger = logging.getLogger(self.__class__.__name__)
 
-    def waiter(self, run_first=False, needs_self=None):
-        """Returns a decorator that sets the decorated coroutine as the waiter for this Task."""
-        if needs_self is None:
-            # If not specified, default to self's value.
-            needs_self = self.needs_self
-
-        def deco(coro):
-            self._waiter = Waiter(coro, run_first=run_first, needs_self=needs_self)
-            return coro
-        return deco
-
-    def exception_handler(self, needs_self=None):
-        """Returns a decorator that sets the decorated coroutine as the exception handler for
-        this Task.
+    def waiter(self, run_first=False):
+        """Returns a decorator that sets the decorated coroutine function as the waiter for this
+        Task.
         """
-        if needs_self is None:
-            # If not specified, default to self's value.
-            needs_self = self.needs_self
 
-        def deco(coro):
-            self._exception_handler = ExceptionHandler(coro, needs_self=needs_self)
-            return coro
-        return deco
+        def decorator(func):
+            self._waiter = Waiter(func, run_first=run_first)
+            return func
+
+        return decorator
+
+    def exception_handler(self):
+        """Returns a decorator that sets the decorated coroutine function as the exception handler
+        for this Task.
+        """
+
+        def decorator(func):
+            self._exception_handler = ExceptionHandler(func)
+            return func
+
+        return decorator
 
     @property
     def running(self):
         return self.asyncio_task is not None and not self.asyncio_task.done()
 
-    def start(self, self_arg=None):
+    def start(self):
         """Starts up the task."""
         if self._waiter is None:
             raise WaiterRequired(self.name)
         if self.running:
             raise TaskAlreadyRunning(self.name)
-        self.logger.info(f'Starting up task `{self.name}`')
-        self.asyncio_task = asyncio.create_task(self._task(self_arg))
+        self.logger.info(f'Starting up task `{self.name}`.')
+        self.asyncio_task = asyncio.create_task(self._task())
 
-    async def manual_trigger(self, self_arg=None, arg=None):
-        """Manually triggers the `coro` with the optionally provided `arg`, which defaults to
+    async def manual_trigger(self, arg=None):
+        """Manually triggers the `func` with the optionally provided `arg`, which defaults to
         `None`.
         """
-        self.logger.info(f'Manually triggering task `{self.name}.')
-        await self._execute_coro(self_arg, arg)
+        self.logger.info(f'Manually triggering task `{self.name}`.')
+        await self._execute_func(arg)
 
     def stop(self):
         """Stops the task, interrupting the currently running coroutines."""
         if self.running:
-            self.logger.info(f'Stopping task `{self.name}`')
+            self.logger.info(f'Stopping task `{self.name}`.')
             self.asyncio_task.cancel()
 
-    async def _task(self, self_arg):
+    async def _task(self):
         arg = None
         if self._waiter.run_first:
-            arg = await self._waiter.wait(self_arg)
+            arg = await self._waiter.wait(self.instance)
         while True:
-            await self._execute_coro(self_arg, arg)
-            arg = await self._waiter.wait(self_arg)
+            await self._execute_func(arg)
+            arg = await self._waiter.wait(self.instance)
 
-    async def _execute_coro(self, self_arg, arg):
+    async def _execute_func(self, arg):
         try:
-            if self.needs_self:
-                await self.coro(self_arg, arg)
+            if self.instance is not None:
+                await self.func(self.instance, arg)
             else:
-                await self.coro(arg)
+                await self.func(arg)
         except Exception as ex:
             self.logger.warning(f'Exception in task `{self.name}`, ignoring.', exc_info=True)
             if self._exception_handler is not None:
-                await self._exception_handler.handle(ex, self_arg)
+                await self._exception_handler.handle(ex, self.instance)
 
 
-def task(*, name, waiter=None, exception_handler=None, needs_self=True):
+class TaskSpec:
+    def __init__(self, name, func, waiter=None, exception_handler=None):
+        _ensure_coroutine_func(func)
+        self.name = name
+        self.func = func
+        self._waiter = waiter
+        self._exception_handler = exception_handler
+
+    def waiter(self, run_first=False, needs_instance=True):
+        """Returns a decorator that sets the decorated coroutine function as the waiter for this
+        TaskSpec.
+        """
+
+        def decorator(func):
+            self._waiter = Waiter(func, run_first=run_first, needs_instance=needs_instance)
+            return func
+
+        return decorator
+
+    def exception_handler(self, needs_instance=True):
+        """Returns a decorator that sets the decorated coroutine function as the exception handler
+        for this TaskSpec.
+        """
+
+        def decorator(func):
+            self._exception_handler = ExceptionHandler(func, needs_instance=needs_instance)
+            return func
+
+        return decorator
+
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self
+        try:
+            tasks = getattr(instance, '___tasks___')
+        except AttributeError:
+            tasks = instance.___tasks___ = {}
+        if self.name not in tasks:
+            tasks[self.name] = Task(self.name, self.func, self._waiter, self._exception_handler,
+                                    instance=instance)
+        return tasks[self.name]
+
+
+def task(*, name, waiter=None, exception_handler=None):
     """Returns a decorator that creates a `Task` with the given options."""
-    def deco(coro):
-        return Task(name, coro, waiter, exception_handler, needs_self=needs_self)
-    return deco
+
+    def decorator(func):
+        return Task(name, func, waiter, exception_handler, instance=None)
+
+    return decorator
+
+
+def task_spec(*, name, waiter=None, exception_handler=None):
+    """Returns a decorator that creates a `TaskSpec` descriptor with the given options."""
+
+    def decorator(func):
+        return TaskSpec(name, func, waiter, exception_handler)
+
+    return decorator

--- a/tle/util/tasks.py
+++ b/tle/util/tasks.py
@@ -83,7 +83,7 @@ class ExceptionHandler:
 class Task:
     """A task that repeats until stopped. A task must have a name, a coroutine function `func` to
     execute periodically and another coroutine function `waiter` to wait on between calls to `func`.
-     The return value of `waiter` is passed to `func` in the next call. An optional coroutine
+    The return value of `waiter` is passed to `func` in the next call. An optional coroutine
     function `exception_handler` may be provided to which exceptions will be reported.
     """
 
@@ -167,6 +167,10 @@ class Task:
 
 
 class TaskSpec:
+    """A descriptor intended to be an interface between an instance and its tasks. It creates
+    the expected task when `__get__` is called from an instance for the first time. No two task
+    specs in the same class should have the same name."""
+
     def __init__(self, name, func, waiter=None, exception_handler=None):
         _ensure_coroutine_func(func)
         self.name = name

--- a/tle/util/tasks.py
+++ b/tle/util/tasks.py
@@ -1,0 +1,163 @@
+import asyncio
+import logging
+
+from discord.ext import commands
+
+import tle.util.codeforces_common as cf_common
+
+
+class TaskError(commands.CommandError):
+    pass
+
+
+class WaiterRequired(TaskError):
+    def __init__(self, name):
+        super().__init__(f'No waiter set for task `{name}`')
+
+
+class TaskAlreadyRunning(TaskError):
+    def __init__(self, name):
+        super().__init__(f'Task `{name}` is already running')
+
+
+class Waiter:
+    def __init__(self, coro, *, run_first=False, needs_self=True):
+        """`run_first` denotes whether this waiter should be run before the task's `coro` when
+        run for the first time. `needs_self` indicates whether a self argument is required by
+        the `coro`.
+        """
+        self.coro = coro
+        self.run_first = run_first
+        self.needs_self = needs_self
+
+    async def wait(self, self_arg=None):
+        if self.needs_self:
+            return await self.coro(self_arg)
+        else:
+            return await self.coro()
+
+    @staticmethod
+    def constant_delay(delay, run_first=False):
+        """Returns a waiter that always waits for the given time (in seconds) and returns the
+        time waited.
+        """
+        async def wait_coro():
+            await asyncio.sleep(delay)
+            return delay
+        return Waiter(wait_coro, run_first=run_first, needs_self=False)
+
+    @staticmethod
+    def for_event(event, run_first=True):
+        """Returns a waiter that waits for the given event and returns the result of that
+        event.
+        """
+        async def wait_coro():
+            return await cf_common.event_sys.wait_for(event)
+        return Waiter(wait_coro, run_first=run_first, needs_self=False)
+
+
+class ExceptionHandler:
+    def __init__(self, coro, *, needs_self=True):
+        """`needs_self` indicates whether a self argument is required by the `coro`."""
+        self.coro = coro
+        self.needs_self = needs_self
+
+    async def handle(self, exception, self_arg=None):
+        if self.needs_self:
+            await self.coro(self_arg, exception)
+        else:
+            await self.coro(exception)
+
+
+class Task:
+    """A task that repeats until stopped. A task must have a name, a coroutine `coro` to execute
+    periodically and another coroutine `waiter` to wait on between calls to `coro`. The return
+    value of `waiter` is passed to `coro` in the next call. An optional coroutine
+    `exception_handler` may be provided to which exceptions will be reported.
+    """
+
+    def __init__(self, name, coro, waiter, exception_handler=None, *, needs_self=True):
+        """`needs_self` indicates whether a self argument is required by the `coro`."""
+        self.name = name
+        self.coro = coro
+        self._waiter = waiter
+        self._exception_handler = exception_handler
+        self.needs_self = needs_self
+        self.asyncio_task = None
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    def waiter(self, run_first=False, needs_self=None):
+        """Returns a decorator that sets the decorated coroutine as the waiter for this Task."""
+        if needs_self is None:
+            # If not specified, default to self's value.
+            needs_self = self.needs_self
+
+        def deco(coro):
+            self._waiter = Waiter(coro, run_first=run_first, needs_self=needs_self)
+            return coro
+        return deco
+
+    def exception_handler(self, needs_self=None):
+        """Returns a decorator that sets the decorated coroutine as the exception handler for
+        this Task.
+        """
+        if needs_self is None:
+            # If not specified, default to self's value.
+            needs_self = self.needs_self
+
+        def deco(coro):
+            self._exception_handler = ExceptionHandler(coro, needs_self=needs_self)
+            return coro
+        return deco
+
+    @property
+    def running(self):
+        return self.asyncio_task is not None and not self.asyncio_task.done()
+
+    def start(self, self_arg=None):
+        """Starts up the task."""
+        if self._waiter is None:
+            raise WaiterRequired(self.name)
+        if self.running:
+            raise TaskAlreadyRunning(self.name)
+        self.logger.info(f'Starting up task `{self.name}`')
+        self.asyncio_task = asyncio.create_task(self._task(self_arg))
+
+    async def manual_trigger(self, self_arg=None, arg=None):
+        """Manually triggers the `coro` with the optionally provided `arg`, which defaults to
+        `None`.
+        """
+        self.logger.info(f'Manually triggering task `{self.name}.')
+        await self._execute_coro(self_arg, arg)
+
+    def stop(self):
+        """Stops the task, interrupting the currently running coroutines."""
+        if self.running:
+            self.logger.info(f'Stopping task `{self.name}`')
+            self.asyncio_task.cancel()
+
+    async def _task(self, self_arg):
+        arg = None
+        if self._waiter.run_first:
+            arg = await self._waiter.wait(self_arg)
+        while True:
+            await self._execute_coro(self_arg, arg)
+            arg = await self._waiter.wait(self_arg)
+
+    async def _execute_coro(self, self_arg, arg):
+        try:
+            if self.needs_self:
+                await self.coro(self_arg, arg)
+            else:
+                await self.coro(arg)
+        except Exception as ex:
+            self.logger.warning(f'Exception in task `{self.name}`, ignoring.', exc_info=True)
+            if self._exception_handler is not None:
+                await self._exception_handler.handle(ex, self_arg)
+
+
+def task(*, name, waiter=None, exception_handler=None, needs_self=True):
+    """Returns a decorator that creates a `Task` with the given options."""
+    def deco(coro):
+        return Task(name, coro, waiter, exception_handler, needs_self=needs_self)
+    return deco


### PR DESCRIPTION
Introduces `Task` objects which take care of repetitive tasks. Resolves #148.

- Each `Task` needs a coroutine to call, a `Waiter` to wait on between calls, and an optional `ExceptionHandler` to notify about exceptions.
- A `Task` once started repeats indefinitely until stopped. The `coro` of a `Task` can also be manually triggered.
- Convenient decorators are implemented to create `Task`s and attach `Waiter`s or `ExceptionHandler`s.

Also introduces `TaskSpec` descriptors that can be created similar to `Tasks`s which take care of creating `Task`s for each instance of a class.

The various caches and the Contests cog have been refactored to reduce *a lot* of clutter!

