### PR TITLE
Extend the invalidation time window

### DIFF
--- a/tle/cogs/duel.py
+++ b/tle/cogs/duel.py
@@ -12,7 +12,7 @@ from tle.util import paginator
 from tle.util import discord_common
 from tle.util import table
 
-_DUEL_INVALIDATE_TIME = 30
+_DUEL_INVALIDATE_TIME = 60
 _DUEL_EXPIRY_TIME = 5 * 60
 _DUEL_RATING_DELTA = -400
 _DUEL_NO_DRAW_TIME = 30 * 60


### PR DESCRIPTION
From 30 seconds to 1 minute, because people don't have inhuman reading speed.