### PR TITLE
Avoid fetching cached ratings while predicting rating changes in ;ranklist.

### DIFF
--- a/tle/util/cache_system2.py
+++ b/tle/util/cache_system2.py
@@ -592,10 +592,11 @@ class RanklistCache:
                 # The contest is not rated
                 ranklist = Ranklist(contest, problems, standings, now, is_rated=False)
             else:
-                get = self.cache_master.rating_changes_cache.get_current_rating
-                current_rating = {row.party.members[0].handle: get(row.party.members[0].handle,
-                                                                   default_if_absent=True)
-                                  for row in standings_official}
+                handles = [row.party.members[0].handle
+                           for row in standings_official]
+                users_info = cf.user.info(handles=handles)
+                current_rating = {user.handle: user.effective_rating
+                                  for user in users_info}
                 if 'Educational' in contest.name:
                     # For some reason educational contests return all contestants in ranklist even
                     # when unofficial contestants are not requested.

--- a/tle/util/cache_system2.py
+++ b/tle/util/cache_system2.py
@@ -558,7 +558,7 @@ class RanklistCache:
 
     async def generate_ranklist(self, contest_id, *, fetch_changes=False, predict_changes=False):
         assert fetch_changes ^ predict_changes
-
+        
         contest, problems, standings = await cf.contest.standings(contest_id=contest_id,
                                                                   show_unofficial=True)
         now = time.time()
@@ -594,7 +594,7 @@ class RanklistCache:
             else:
                 handles = [row.party.members[0].handle
                            for row in standings_official]
-                users_info = cf.user.info(handles=handles)
+                users_info = await cf.user.info(handles=handles)
                 current_rating = {user.handle: user.effective_rating
                                   for user in users_info}
                 if 'Educational' in contest.name:

--- a/tle/util/codeforces_api.py
+++ b/tle/util/codeforces_api.py
@@ -16,6 +16,7 @@ PROFILE_BASE_URL = 'https://codeforces.com/profile/'
 ACMSGURU_BASE_URL = 'https://codeforces.com/problemsets/acmsguru/'
 GYM_ID_THRESHOLD = 100000
 DEFAULT_RATING = 1500
+MAX_HANDLES_PER_QUERY = 300 # To avoid sending too large requests.
 
 logger = logging.getLogger(__name__)
 
@@ -331,6 +332,9 @@ class problemset:
 class user:
     @staticmethod
     async def info(*, handles):
+        if len(handles) > MAX_HANDLES_PER_QUERY:
+            return await user.info(handles=handles[:MAX_HANDLES_PER_QUERY]) + \
+                   await user.info(handles=handles[MAX_HANDLES_PER_QUERY:])
         params = {'handles': ';'.join(handles)}
         try:
             resp = await _query_api('user.info', params)


### PR DESCRIPTION
Query CF API for user ratings instead of fetching them from the cache. cheran-senthil#224