### PR TITLE
Replace all uses of zero width space and \0

### DIFF
--- a/tle/cogs/duel.py
+++ b/tle/cogs/duel.py
@@ -522,8 +522,12 @@ class Dueling(commands.Cog):
         plt.xlim(0, time_tick - 1)
         plt.ylim(min_rating - 100, max_rating + 100)
 
-        labels = ['{} ({})'.format(ctx.guild.get_member(duelist).display_name, rating_data[-1][1])
-                  for duelist, rating_data in plot_data.items()]
+        labels = [
+            gc.StrWrap('{} ({})'.format(
+                ctx.guild.get_member(duelist).display_name,
+                rating_data[-1][1]))
+            for duelist, rating_data in plot_data.items()
+        ]
         plt.legend(labels, loc='upper left')
 
         discord_file = gc.get_current_figure_as_file()

--- a/tle/cogs/graphs.py
+++ b/tle/cogs/graphs.py
@@ -224,7 +224,7 @@ class Graphs(commands.Cog):
         plt.clf()
         _plot_rating(resp)
         current_ratings = [rating_changes[-1].newRating if rating_changes else 'Unrated' for rating_changes in resp]
-        labels = [f'\N{ZERO WIDTH SPACE}{handle} ({rating})' for handle, rating in zip(handles, current_ratings)]
+        labels = [gc.StrWrap(f'{handle} ({rating})') for handle, rating in zip(handles, current_ratings)]
         plt.legend(labels, loc='upper left')
 
         if not zoom:
@@ -322,7 +322,7 @@ class Graphs(commands.Cog):
             # NOTE: matplotlib ignores labels that begin with _
             # https://matplotlib.org/api/pyplot_api.html#matplotlib.pyplot.legend
             # Add zero-width space to work around this
-            labels = [f'\N{ZERO WIDTH SPACE}{handle}: {len(ratings)}'
+            labels = [gc.StrWrap(f'{handle}: {len(ratings)}')
                       for handle, ratings in zip(handles, all_ratings)]
 
             step = 200
@@ -371,7 +371,7 @@ class Graphs(commands.Cog):
             # NOTE: matplotlib ignores labels that begin with _
             # https://matplotlib.org/api/pyplot_api.html#matplotlib.pyplot.legend
             # Add zero-width space to work around this
-            labels = [f'\N{ZERO WIDTH SPACE}{handle}: {len(times)}'
+            labels = [gc.StrWrap(f'{handle}: {len(times)}')
                       for handle, times in zip(handles, all_times)]
 
             plt.hist(all_times, label=labels)
@@ -655,7 +655,7 @@ class Graphs(commands.Cog):
         # shift the [-300, 300] gitgud range to center the text
         hist_bins = list(range(-300 - 50, 300 + 50 + 1, 100))
         deltas = [[x[0] for x in cf_common.user_db.howgud(member.id)] for member in members]
-        labels = [f'\0{member.display_name}: {len(delta)}'
+        labels = [gc.StrWrap(f'{member.display_name}: {len(delta)}')
                   for member, delta in zip(members, deltas)]
 
         plt.clf()

--- a/tle/cogs/graphs.py
+++ b/tle/cogs/graphs.py
@@ -318,10 +318,6 @@ class Graphs(commands.Cog):
         else:
             all_ratings = [[sub.problem.rating for sub in solved_subs]
                            for solved_subs in all_solved_subs]
-
-            # NOTE: matplotlib ignores labels that begin with _
-            # https://matplotlib.org/api/pyplot_api.html#matplotlib.pyplot.legend
-            # Add zero-width space to work around this
             labels = [gc.StrWrap(f'{handle}: {len(ratings)}')
                       for handle, ratings in zip(handles, all_ratings)]
 

--- a/tle/util/graph_common.py
+++ b/tle/util/graph_common.py
@@ -6,7 +6,12 @@ import time
 from tle import constants
 from matplotlib import pyplot as plt
 
+
 # String wrapper to avoid the underscore behavior in legends
+#
+# In legends, matplotlib ignores labels that begin with _
+# https://matplotlib.org/api/pyplot_api.html#matplotlib.pyplot.legend
+# However, this check is only done for actual string objects.
 class StrWrap:
     def __init__(self, s):
         self.string = s

--- a/tle/util/graph_common.py
+++ b/tle/util/graph_common.py
@@ -6,6 +6,13 @@ import time
 from tle import constants
 from matplotlib import pyplot as plt
 
+# String wrapper to avoid the underscore behavior in legends
+class StrWrap:
+    def __init__(self, s):
+        self.string = s
+    def __str__(self):
+        return self.string
+
 def get_current_figure_as_file():
     filename = os.path.join(constants.TEMP_DIR, f'tempplot_{time.time()}.png')
     plt.savefig(filename, facecolor=plt.gca().get_facecolor(), bbox_inches='tight', pad_inches=0.25)


### PR DESCRIPTION
Only actual strings are checked for leading underscores, and in the end `str` is called on the object passes. So passing a wrapped string will bypass the checks.