### PR TITLE
Split too large user.info requests

### DIFF
--- a/tle/util/codeforces_api.py
+++ b/tle/util/codeforces_api.py
@@ -16,6 +16,7 @@ PROFILE_BASE_URL = 'https://codeforces.com/profile/'
 ACMSGURU_BASE_URL = 'https://codeforces.com/problemsets/acmsguru/'
 GYM_ID_THRESHOLD = 100000
 DEFAULT_RATING = 1500
+MAX_HANDLES_PER_QUERY = 300 # To avoid sending too large requests.
 
 logger = logging.getLogger(__name__)
 
@@ -335,6 +336,9 @@ class problemset:
 class user:
     @staticmethod
     async def info(*, handles):
+        if len(handles) > MAX_HANDLES_PER_QUERY:
+            return await user.info(handles=handles[:MAX_HANDLES_PER_QUERY]) + \
+                   await user.info(handles=handles[MAX_HANDLES_PER_QUERY:])
         params = {'handles': ';'.join(handles)}
         try:
             resp = await _query_api('user.info', params)

--- a/tle/util/codeforces_api.py
+++ b/tle/util/codeforces_api.py
@@ -3,6 +3,7 @@ import logging
 import time
 import functools
 from collections import namedtuple, deque
+import math
 
 import aiohttp
 
@@ -337,6 +338,8 @@ class user:
     @staticmethod
     async def info(*, handles):
         if len(handles) > MAX_HANDLES_PER_QUERY:
+            logger.warning(f'cf.info request with {len(handles)} handles, \
+            will be chunkified into {math.ceil(len(handles) / MAX_HANDLES_PER_QUERY)} requests.')
             return await user.info(handles=handles[:MAX_HANDLES_PER_QUERY]) + \
                    await user.info(handles=handles[MAX_HANDLES_PER_QUERY:])
         params = {'handles': ';'.join(handles)}

--- a/tle/util/codeforces_api.py
+++ b/tle/util/codeforces_api.py
@@ -3,7 +3,7 @@ import logging
 import time
 import functools
 from collections import namedtuple, deque
-import math
+from tle.util.paginator import chunkify
 
 import aiohttp
 
@@ -338,10 +338,11 @@ class user:
     @staticmethod
     async def info(*, handles):
         if len(handles) > MAX_HANDLES_PER_QUERY:
+            chunks = chunkify(handles, MAX_HANDLES_PER_QUERY)
             logger.warning(f'cf.info request with {len(handles)} handles, \
-            will be chunkified into {math.ceil(len(handles) / MAX_HANDLES_PER_QUERY)} requests.')
-            return await user.info(handles=handles[:MAX_HANDLES_PER_QUERY]) + \
-                   await user.info(handles=handles[MAX_HANDLES_PER_QUERY:])
+            will be chunkified into {len(chunks)} requests.')
+            for chunk in chunks:
+                await user.info(handles=chunk)
         params = {'handles': ';'.join(handles)}
         try:
             resp = await _query_api('user.info', params)


### PR DESCRIPTION
If `user.info`request has too many handles, the request URL will too large and thus the request will fail with [this error](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/414).

So, a simple fix is to split the too large request into small enough requests.

The possible drawback here is that the request will take significantly more time, due to rate-limiting.