### PR TITLE
Add poetry install in run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -7,6 +7,7 @@ cd "$(dirname "$0")"
 
 while true; do
     git pull
+    poetry install
     FONTCONFIG_FILE=$PWD/extra/fonts.conf poetry run python -m tle
 
     (( $? != 42 )) && break


### PR DESCRIPTION
`git pull` pulls the remote changes, which may include new libraries, so it's needed to do `poetry install` before launching the bot in that case.