### PR TITLE
Add visualrank plot (#256)

### DIFF
--- a/tle/cogs/graphs.py
+++ b/tle/cogs/graphs.py
@@ -749,14 +749,14 @@ class Graphs(commands.Cog):
         handles = await cf_common.resolve_handles(ctx, self.converter, handles, mincnt=0, maxcnt=20)
 
         rating_changes = await cf.contest.ratingChanges(contest_id=contest_id)
+        if in_server:
+            guild_handles = set(handle for discord_id, handle
+                                in cf_common.user_db.get_handles_for_guild(ctx.guild.id))
+            rating_changes = [rating_change for rating_change in rating_changes
+                              if rating_change.handle in guild_handles]
 
         if not rating_changes:
             raise GraphCogError(f'No rating changes for contest `{contest_id}`')
-
-        if in_server:
-            guild_handles = [handle for discord_id, handle
-                             in cf_common.user_db.get_handles_for_guild(ctx.guild.id)]
-            rating_changes = [rating_change for rating_change in rating_changes if rating_change.handle in guild_handles]
 
         ranks = []
         delta = []

--- a/tle/cogs/graphs.py
+++ b/tle/cogs/graphs.py
@@ -753,7 +753,7 @@ class Graphs(commands.Cog):
             guild_handles = set(handle for discord_id, handle
                                 in cf_common.user_db.get_handles_for_guild(ctx.guild.id))
             rating_changes = [rating_change for rating_change in rating_changes
-                              if rating_change.handle in guild_handles]
+                              if rating_change.handle in guild_handles or rating_change.handle in handles]
 
         if not rating_changes:
             raise GraphCogError(f'No rating changes for contest `{contest_id}`')

--- a/tle/cogs/graphs.py
+++ b/tle/cogs/graphs.py
@@ -758,28 +758,11 @@ class Graphs(commands.Cog):
         if not rating_changes:
             raise GraphCogError(f'No rating changes for contest `{contest_id}`')
 
-        ranks = []
-        delta = []
-        color = []
         users_to_mark = {}
-
         for rating_change in rating_changes:
             user_delta = rating_change.newRating - rating_change.oldRating
-
-            ranks.append(rating_change.rank)
-            delta.append(user_delta)
-            color.append(cf.rating2rank(rating_change.oldRating).color_graph)
-
             if rating_change.handle in handles:
                 users_to_mark[rating_change.handle] = (rating_change.rank, user_delta)
-
-        title = rating_changes[0].contestName
-
-        plt.clf()
-        fig = plt.figure(figsize=(12, 8))
-        plt.title(title)
-        plt.xlabel('Rank')
-        plt.ylabel('Rating Changes')
 
         ymargin = 50
         xmargin = 50
@@ -799,7 +782,27 @@ class Graphs(commands.Cog):
             ymin = -ylim
             ymax = ylim
 
-        mark_size = 2e4 / (xmax - xmin + 2 * xmargin)
+        ranks = []
+        delta = []
+        color = []
+        for rating_change in rating_changes:
+            user_delta = rating_change.newRating - rating_change.oldRating
+
+            if (xmin - xmargin <= rating_change.rank <= xmax + xmargin
+                    and ymin - ymargin <= user_delta <= ymax + ymargin):
+                ranks.append(rating_change.rank)
+                delta.append(user_delta)
+                color.append(cf.rating2rank(rating_change.oldRating).color_graph)
+
+        title = rating_changes[0].contestName
+
+        plt.clf()
+        fig = plt.figure(figsize=(12, 8))
+        plt.title(title)
+        plt.xlabel('Rank')
+        plt.ylabel('Rating Changes')
+
+        mark_size = 2e4 / len(ranks)
         plt.xlim(xmin - xmargin, xmax + xmargin)
         plt.ylim(ymin - ymargin, ymax + ymargin)
         plt.scatter(ranks, delta, s=mark_size, c=color)

--- a/tle/cogs/graphs.py
+++ b/tle/cogs/graphs.py
@@ -761,17 +761,17 @@ class Graphs(commands.Cog):
         ranks = []
         delta = []
         color = []
-        users_to_mark = dict()
+        users_to_mark = {}
 
-        for user in rating_changes:
-            user_delta = user.newRating - user.oldRating
+        for rating_change in rating_changes:
+            user_delta = rating_change.newRating - rating_change.oldRating
 
-            ranks.append(user.rank)
+            ranks.append(rating_change.rank)
             delta.append(user_delta)
-            color.append(cf.rating2rank(user.oldRating).color_graph)
+            color.append(cf.rating2rank(rating_change.oldRating).color_graph)
 
-            if user.handle in handles:
-                users_to_mark[user.handle] = (user.rank, user_delta)
+            if rating_change.handle in handles:
+                users_to_mark[rating_change.handle] = (rating_change.rank, user_delta)
 
         title = rating_changes[0].contestName
 
@@ -788,21 +788,20 @@ class Graphs(commands.Cog):
             xmax = max(point[0] for point in users_to_mark.values())
             ymin = min(point[1] for point in users_to_mark.values())
             ymax = max(point[1] for point in users_to_mark.values())
-            mark_size = 2e4 / (xmax - xmin + 2 * xmargin)
-
-            plt.xlim(xmin - xmargin, xmax + xmargin)
-            plt.ylim(ymin - ymargin, ymax + ymargin)
         else:
             ylim = 0
             if users_to_mark:
                 ylim = max(abs(point[1]) for point in users_to_mark.values())
             ylim = max(ylim, 200)
-            xmax = max(user.rank for user in rating_changes)
-            mark_size = 2e4 / (xmax + 2 * xmargin)
 
-            plt.xlim(-xmargin, xmax + xmargin)
-            plt.ylim(-ylim - ymargin, ylim + ymargin)
+            xmin = 0
+            xmax = max(rating_change.rank for rating_change in rating_changes)
+            ymin = -ylim
+            ymax = ylim
 
+        mark_size = 2e4 / (xmax - xmin + 2 * xmargin)
+        plt.xlim(xmin - xmargin, xmax + xmargin)
+        plt.ylim(ymin - ymargin, ymax + ymargin)
         plt.scatter(ranks, delta, s=mark_size, c=color)
 
         for handle, point in users_to_mark.items():


### PR DESCRIPTION
Closes #256
I added command `;plot visualrank [handles...]` as discussed in #256.
It can specify handles in the plot like `;plot visualrank <contest_id> tourist`. Also, it can be zoomed using `+zoom`.
Using `+server` will just add server members to the plot (not all of codeforces users).
These are samples generated by the code:
`;plot visualrank 1368 antontrygubO_o`
![plot](https://user-images.githubusercontent.com/33874579/88047849-83b57a00-cb67-11ea-8207-47ef85ea0b67.png)
`;plot visualrank 1368 antontrygubO_o tourist +zoom`
![zoom](https://user-images.githubusercontent.com/33874579/88047895-95971d00-cb67-11ea-8192-76ab2ddf5f2a.png)
