### PR TITLE
fixed rating calculation for handle_rating_cache

### DIFF
--- a/tle/util/cache_system2.py
+++ b/tle/util/cache_system2.py
@@ -467,11 +467,7 @@ class RatingChangesCache:
         changes = self.cache_master.conn.get_all_rating_changes()
         handle_rating_cache = {}
         for change in changes:
-            delta = change.newRating - change.oldRating
-            try:
-                handle_rating_cache[change.handle] += delta
-            except KeyError:
-                handle_rating_cache[change.handle] = cf.DEFAULT_RATING + delta
+            handle_rating_cache[change.handle] = change.newRating
         self.handle_rating_cache = handle_rating_cache
         self.logger.info(f'Ratings for {len(handle_rating_cache)} handles cached')
 

--- a/tle/util/db/cache_db_conn.py
+++ b/tle/util/db/cache_db_conn.py
@@ -147,7 +147,8 @@ class CacheDbConn:
         query = ('SELECT contest_id, name, handle, rank, rating_update_time, old_rating, new_rating '
                  'FROM rating_change r '
                  'LEFT JOIN contest c '
-                 'ON r.contest_id = c.id')
+                 'ON r.contest_id = c.id '
+                 'ORDER BY rating_update_time')
         res = self.conn.execute(query)
         return (cf.RatingChange._make(change) for change in res)
 


### PR DESCRIPTION
Due to change of default rating by CF, rating calculation for handle_rating_cache was broken (`print(self.handle_rating_cache['Vivekomji'])` should print display rating (361) or real rating(1261), instead it used to print 1861. After these changes display rating is stored in handle_rating_cache.