### PR TITLE
Add relativeTimeSeconds to Submission namedtuple

### DIFF
--- a/tle/util/codeforces_api.py
+++ b/tle/util/codeforces_api.py
@@ -132,7 +132,7 @@ class Problem(namedtuple('Problem', 'contestId problemsetName index name type po
 ProblemStatistics = namedtuple('ProblemStatistics', 'contestId index solvedCount')
 
 Submission = namedtuple('Submissions',
-                        'id contestId problem author programmingLanguage verdict creationTimeSeconds')
+                        'id contestId problem author programmingLanguage verdict creationTimeSeconds relativeTimeSeconds')
 
 RanklistRow = namedtuple('RanklistRow', 'party rank points penalty problemResults')
 


### PR DESCRIPTION
This fixes a bug in ratedvc where it was checking `submission.relativeTimeSeconds` while it was not there in [this line](https://github.com/cheran-senthil/TLE/blob/master/tle/cogs/contests.py#L600).
