### PR TITLE
Add documentation about environment variables to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Fill in appropriate variables in new "environment" file.
 #### Environment Variables
 
 **BOT_TOKEN**: the Discord Bot Token for your bot.  
-**LOGGING_COG_CHANNEL_ID**: the ID of a Discord Channel where you want error messages sent to.
+**LOGGING_COG_CHANNEL_ID**: the [Discord Channel ID](https://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID-) of a Discord Channel where you want error messages sent to.
 
 To start TLE just run:
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ cp environment.template environment
 
 Fill in appropriate variables in new "environment" file.
 
+#### Environment Variables
+
+**BOT_TOKEN**: the Discord Bot Token for your bot.  
+**LOGGING_COG_CHANNEL_ID**: the ID of a Discord Channel where you want error messages sent to.
+
 To start TLE just run:
 
 ```bash


### PR DESCRIPTION
We added LOGGING_COG_CHANNEL_ID to environment file in #388 to hint to the users that there's logging functionality available. This PR adds some documentation about how to use them.