### PR TITLE
Added minimum rating for gitgud, to 1000. Could maybe be 1100

### DIFF
--- a/tle/cogs/codeforces.py
+++ b/tle/cogs/codeforces.py
@@ -19,6 +19,8 @@ from tle.util import cache_system2
 _GITGUD_NO_SKIP_TIME = 3 * 60 * 60
 _GITGUD_SCORE_DISTRIB = (2, 3, 5, 8, 12, 17, 23)
 _GITGUD_MAX_ABS_DELTA_VALUE = 300
+#Minimum rating so that beginners can solve 800-1300 problems. Can change(maybe) to 1100, so they can solve 800-1400. No problem on codeforces with <800 rating
+_GITGUD_MIN_RATING = 1000
 
 
 class CodeforcesCogError(commands.CommandError):
@@ -71,6 +73,8 @@ class Codeforces(commands.Cog):
         handle, = await cf_common.resolve_handles(ctx, self.converter, ('!' + str(ctx.author),))
         user = cf_common.user_db.fetch_cf_user(handle)
         rating = round(user.effective_rating, -2)
+        #minimum rating so that beginners can solve problems
+        rating = max(rating, _GITGUD_MIN_RATING)
         resp = await cf.user.rating(handle=handle)
         contests = {change.contestId for change in resp}
         submissions = await cf.user.status(handle=handle)
@@ -225,6 +229,8 @@ class Codeforces(commands.Cog):
         handle, = await cf_common.resolve_handles(ctx, self.converter, ('!' + str(ctx.author),))
         user = cf_common.user_db.fetch_cf_user(handle)
         rating = round(user.effective_rating, -2)
+        #minimum rating so that beginners can solve problems
+        rating = max(rating, _GITGUD_MIN_RATING)
         submissions = await cf.user.status(handle=handle)
         solved = {sub.problem.name for sub in submissions}
         noguds = cf_common.user_db.get_noguds(ctx.message.author.id)


### PR DESCRIPTION
Hey, so I added a minimum rating for gitgud. It is especially useful for beginners, to be able to solve problems in the 800-1300 range. I set it to 1000 currently, 1100 would allow for 800-1400, but it could be discouraging for beginners, maybe.