### PR TITLE
Help format

### DIFF
--- a/tle/__main__.py
+++ b/tle/__main__.py
@@ -58,11 +58,13 @@ def main():
         constants.ALLOW_DUEL_SELF_REGISTER = bool(distutils.util.strtobool(allow_self_register))
 
     setup()
-    
+
     intents = discord.Intents.default()
     intents.members = True
 
-    bot = commands.Bot(command_prefix=commands.when_mentioned_or(';'), intents=intents)
+    bot = commands.Bot(command_prefix=commands.when_mentioned_or(';'),
+                       intents=intents,
+                       help_command=discord_common.TLEHelpCommand())
     cogs = [file.stem for file in Path('tle', 'cogs').glob('*.py')]
     for extension in cogs:
         bot.load_extension(f'tle.cogs.{extension}')

--- a/tle/cogs/codeforces.py
+++ b/tle/cogs/codeforces.py
@@ -62,8 +62,8 @@ class Codeforces(commands.Cog):
     @commands.command(brief='Upsolve a problem')
     @cf_common.user_guard(group='gitgud')
     async def upsolve(self, ctx, choice: int = -1):
-        """Request an unsolved problem from a contest you participated in
-        delta  | -300 | -200 | -100 |  0  | +100 | +200 | +300
+        """Request an unsolved problem from a contest you participated in\\
+        delta  | -300 | -200 | -100 |  0  | +100 | +200 | +300\\
         points |   2  |   3  |   5  |  8  |  12  |  17  |  23
         """
         await self._validate_gitgud_status(ctx,delta=None)
@@ -219,8 +219,8 @@ class Codeforces(commands.Cog):
     @commands.command(brief='Challenge')
     @cf_common.user_guard(group='gitgud')
     async def gitgud(self, ctx, delta: int = 0):
-        """Request a problem for gitgud points.
-        delta  | -300 | -200 | -100 |  0  | +100 | +200 | +300
+        """Request a problem for gitgud points.\\
+        delta  | -300 | -200 | -100 |  0  | +100 | +200 | +300\\
         points |   2  |   3  |   5  |  8  |  12  |  17  |  23
         """
         await self._validate_gitgud_status(ctx, delta)


### PR DESCRIPTION
Remove single newlines in help strings (that are generated from the docstrings). Newlines prefixed with `\\` remain, double newlines (paragraphs) remain. (May or may not behave akin to LaTeX now.)