### PR TITLE
Add commands to handle cf magic (user name change)

### DIFF
--- a/tle/cogs/handles.py
+++ b/tle/cogs/handles.py
@@ -432,9 +432,9 @@ class Handles(commands.Cog):
         await ctx.send(embed=embed)
 
     @handle.command(brief='Resolve redirect of a user\'s handle')
-    @commands.has_any_role('Admin', 'Moderator')
     async def unmagic(self, ctx):
-        """Remove Codeforces handle of a user."""
+        """Updates handle of the calling user if they have changed handles
+        (typically new year's magic)"""
         member = ctx.author
         handle = cf_common.user_db.get_handle(member.id, ctx.guild.id)
         redirected_handle = await cf.resolve_redirect(handle)
@@ -453,6 +453,8 @@ class Handles(commands.Cog):
     @handle.command(brief='Resolve handles needing redirection')
     @commands.has_any_role('Admin', 'Moderator')
     async def unmagic_all(self, ctx):
+        """Updates handles of all users that have changed handles
+        (typically new year's magic)"""
         handles = []
         rev_lookup = {}
         for user_id, handle in cf_common.user_db.get_handles_for_guild(

--- a/tle/util/codeforces_api.py
+++ b/tle/util/codeforces_api.py
@@ -403,12 +403,13 @@ class user:
 
 async def resolve_redirect(handle):
     url = 'http://codeforces.com/profile/' + handle
-    async with _session.head(url, allow_redirects=True) as r:
-        if r.url.parts[:-1] != ('/', 'profile'):
-            # Ended up not on profile page, probably invalid handle
-            return None
-        if r.status != 200:
-            # Something went wrong
-            return None
-        # Return the handle in the final url
-        return r.url.parts[-1]
+    async with _session.head(url) as r:
+        if r.status == 200:
+            return handle
+        if r.status == 302:
+            redirected = r.headers.get('Location')
+            if '/profile/' not in redirected:
+                # Ended up not on profile page, probably invalid handle
+                return None
+            return redirected.split('/profile/')[-1]
+        raise CodeforcesApiError(f'Something went wrong trying to redirect {url}')

--- a/tle/util/codeforces_api.py
+++ b/tle/util/codeforces_api.py
@@ -168,14 +168,14 @@ class ClientError(CodeforcesApiError):
 
 class HandleNotFoundError(TrueApiError):
     def __init__(self, comment, handle):
-        self.handle = handle
         super().__init__(comment, f'Handle `{handle}` not found on Codeforces')
+        self.handle = handle
 
 
 class HandleInvalidError(TrueApiError):
     def __init__(self, comment, handle):
-        self.handle = handle
         super().__init__(comment, f'`{handle}` is not a valid Codeforces handle')
+        self.handle = handle
 
 
 class CallLimitExceededError(TrueApiError):
@@ -400,3 +400,15 @@ class user:
                                                for member in submission['author']['members']]
             submission['author'] = make_from_dict(Party, submission['author'])
         return [make_from_dict(Submission, submission_dict) for submission_dict in resp]
+
+async def resolve_redirect(handle):
+    url = 'http://codeforces.com/profile/' + handle
+    async with _session.head(url, allow_redirects=True) as r:
+        if r.url.parts[:-1] != ('/', 'profile'):
+            # Ended up not on profile page, probably invalid handle
+            return None
+        if r.status != 200:
+            # Something went wrong
+            return None
+        # Return the handle in the final url
+        return r.url.parts[-1]

--- a/tle/util/codeforces_api.py
+++ b/tle/util/codeforces_api.py
@@ -168,11 +168,13 @@ class ClientError(CodeforcesApiError):
 
 class HandleNotFoundError(TrueApiError):
     def __init__(self, comment, handle):
+        self.handle = handle
         super().__init__(comment, f'Handle `{handle}` not found on Codeforces')
 
 
 class HandleInvalidError(TrueApiError):
     def __init__(self, comment, handle):
+        self.handle = handle
         super().__init__(comment, f'`{handle}` is not a valid Codeforces handle')
 
 

--- a/tle/util/codeforces_common.py
+++ b/tle/util/codeforces_common.py
@@ -1,15 +1,13 @@
-from collections import defaultdict
-import datetime
 import functools
-import itertools
 import json
 import logging
 import math
 import time
-
-import aiohttp
-import discord
+import datetime
+from collections import defaultdict
+import itertools
 from discord.ext import commands
+import discord
 
 from tle import constants
 from tle.util import cache_system2
@@ -33,6 +31,7 @@ _contest_id_to_writers_map = None
 _initialize_done = False
 
 active_groups = defaultdict(set)
+
 
 async def initialize(nodb):
     global cache2

--- a/tle/util/codeforces_common.py
+++ b/tle/util/codeforces_common.py
@@ -1,13 +1,15 @@
+from collections import defaultdict
+import datetime
 import functools
+import itertools
 import json
 import logging
 import math
 import time
-import datetime
-from collections import defaultdict
-import itertools
-from discord.ext import commands
+
+import aiohttp
 import discord
+from discord.ext import commands
 
 from tle import constants
 from tle.util import cache_system2
@@ -32,12 +34,14 @@ _initialize_done = False
 
 active_groups = defaultdict(set)
 
+_session = None
 
 async def initialize(nodb):
     global cache2
     global user_db
     global event_sys
     global _contest_id_to_writers_map
+    global _session
     global _initialize_done
 
     if _initialize_done:
@@ -63,6 +67,8 @@ async def initialize(nodb):
         logger.info('Contest writers loaded from JSON file')
     except FileNotFoundError:
         logger.warning('JSON file containing contest writers not found')
+
+    _session = aiohttp.ClientSession()
 
     _initialize_done = True
 
@@ -380,3 +386,15 @@ class SubFilter:
         rating_changes = [change for change in rating_changes
                     if self.dlo <= change.ratingUpdateTimeSeconds < self.dhi]
         return rating_changes
+
+async def resolve_redirect(handle):
+    url = 'http://codeforces.com/profile/' + handle
+    async with _session.head(url, allow_redirects=True) as r:
+        if r.url.parts[:-1] != ('/', 'profile'):
+            # Ended up not on profile page, probably invalid handle
+            return None
+        if r.status != 200:
+            # Something went wrong
+            return None
+        # Return the handle in the final url
+        return r.url.parts[-1]

--- a/tle/util/codeforces_common.py
+++ b/tle/util/codeforces_common.py
@@ -34,14 +34,11 @@ _initialize_done = False
 
 active_groups = defaultdict(set)
 
-_session = None
-
 async def initialize(nodb):
     global cache2
     global user_db
     global event_sys
     global _contest_id_to_writers_map
-    global _session
     global _initialize_done
 
     if _initialize_done:
@@ -67,8 +64,6 @@ async def initialize(nodb):
         logger.info('Contest writers loaded from JSON file')
     except FileNotFoundError:
         logger.warning('JSON file containing contest writers not found')
-
-    _session = aiohttp.ClientSession()
 
     _initialize_done = True
 
@@ -386,15 +381,3 @@ class SubFilter:
         rating_changes = [change for change in rating_changes
                     if self.dlo <= change.ratingUpdateTimeSeconds < self.dhi]
         return rating_changes
-
-async def resolve_redirect(handle):
-    url = 'http://codeforces.com/profile/' + handle
-    async with _session.head(url, allow_redirects=True) as r:
-        if r.url.parts[:-1] != ('/', 'profile'):
-            # Ended up not on profile page, probably invalid handle
-            return None
-        if r.status != 200:
-            # Something went wrong
-            return None
-        # Return the handle in the final url
-        return r.url.parts[-1]


### PR DESCRIPTION
Follows the cf profile link to find the new user name.  Includes a command to try to resolve redirects for the whole guild.  This uses the fact that user.info returns the first failing user name in its response.