### PR TITLE
Improve logging output

### DIFF
--- a/tle/cogs/cache_control.py
+++ b/tle/cogs/cache_control.py
@@ -84,17 +84,7 @@ class CacheControl(commands.Cog):
         await ctx.send(f'Done, fetched {count} problems')
 
     async def cog_command_error(self, ctx, error):
-        if isinstance(error, commands.CommandInvokeError):
-            error = error.__cause__
-        lines = traceback.format_exception(type(error), error, error.__traceback__)
-        msg = '\n'.join(lines)
-        discord_msg_char_limit = 2000
-        char_limit = discord_msg_char_limit - 2 * len('```')
-        too_long = len(msg) > char_limit
-        msg = msg[:char_limit]
-        await ctx.send(f'```{msg}```')
-        if too_long:
-            await ctx.send('Check logs for full stack trace')
+        pass
 
 
 def setup(bot):

--- a/tle/cogs/cache_control.py
+++ b/tle/cogs/cache_control.py
@@ -83,9 +83,6 @@ class CacheControl(commands.Cog):
             count = await cf_common.cache2.problemset_cache.update_for_contest(contest_id)
         await ctx.send(f'Done, fetched {count} problems')
 
-    async def cog_command_error(self, ctx, error):
-        pass
-
 
 def setup(bot):
     bot.add_cog(CacheControl(bot))

--- a/tle/cogs/logging.py
+++ b/tle/cogs/logging.py
@@ -40,10 +40,10 @@ class Logging(commands.Cog, logging.Handler):
                 break
             try:
                 msg = self.format(record)
-                # Not all errors have jump urls.
+                # Not all errors will have message_contents or jump urls.
                 try:
                     await channel.send(
-                        '```Original Command: {}\nJump Url: {}```'.format(
+                        'Original Command: {}\nJump Url: {}'.format(
                             record.message_content, record.jump_url))
                 except AttributeError:
                     pass

--- a/tle/cogs/logging.py
+++ b/tle/cogs/logging.py
@@ -36,15 +36,16 @@ class Logging(commands.Cog, logging.Handler):
             if channel is None:
                 # Channel no longer exists.
                 root_logger.removeHandler(self)
-                self.logger.warning(
-                    'Logging channel not available, disabling Discord log handler.')
+                self.logger.warning('Logging channel not available, disabling Discord log handler.')
                 break
             try:
                 msg = self.format(record)
-                await channel.send('```Original Command: {}```'.format(record.message_content))
                 # Not all errors have jump urls.
                 try:
-                    channel.send('```Jump Url: {}```'.format(record.jump_url))
+                    await channel.send('```Original Command: {}```'.format(
+                        record.message_content))
+                    await channel.send('```Jump Url: {}```'.format(
+                        record.jump_url))
                 except AttributeError:
                     pass
                 discord_msg_char_limit = 2000
@@ -70,8 +71,7 @@ class Logging(commands.Cog, logging.Handler):
 def setup(bot):
     logging_cog_channel_id = os.environ.get('LOGGING_COG_CHANNEL_ID')
     if logging_cog_channel_id is None:
-        logger.info(
-            'Skipping installation of logging cog as logging channel is not provided.')
+        logger.info('Skipping installation of logging cog as logging channel is not provided.')
         return
 
     logging_cog = Logging(bot, int(logging_cog_channel_id))

--- a/tle/cogs/logging.py
+++ b/tle/cogs/logging.py
@@ -42,10 +42,9 @@ class Logging(commands.Cog, logging.Handler):
                 msg = self.format(record)
                 # Not all errors have jump urls.
                 try:
-                    await channel.send('```Original Command: {}```'.format(
-                        record.message_content))
-                    await channel.send('```Jump Url: {}```'.format(
-                        record.jump_url))
+                    await channel.send(
+                        '```Original Command: {}\nJump Url: {}```'.format(
+                            record.message_content, record.jump_url))
                 except AttributeError:
                     pass
                 discord_msg_char_limit = 2000

--- a/tle/cogs/logging.py
+++ b/tle/cogs/logging.py
@@ -36,13 +36,15 @@ class Logging(commands.Cog, logging.Handler):
             if channel is None:
                 # Channel no longer exists.
                 root_logger.removeHandler(self)
-                self.logger.warning('Logging channel not available, disabling Discord log handler.')
+                self.logger.warning(
+                    'Logging channel not available, disabling Discord log handler.')
                 break
             try:
                 msg = self.format(record)
+                await channel.send('```Original Command: {}```'.format(record.message_content))
+                # Not all errors have jump urls.
                 try:
-                    await channel.send(
-                        embed=discord_common.embed_failed_command(record))
+                    channel.send('```Jump Url: {}```'.format(record.jump_url))
                 except AttributeError:
                     pass
                 discord_msg_char_limit = 2000
@@ -68,7 +70,8 @@ class Logging(commands.Cog, logging.Handler):
 def setup(bot):
     logging_cog_channel_id = os.environ.get('LOGGING_COG_CHANNEL_ID')
     if logging_cog_channel_id is None:
-        logger.info('Skipping installation of logging cog as logging channel is not provided.')
+        logger.info(
+            'Skipping installation of logging cog as logging channel is not provided.')
         return
 
     logging_cog = Logging(bot, int(logging_cog_channel_id))

--- a/tle/cogs/logging.py
+++ b/tle/cogs/logging.py
@@ -41,7 +41,8 @@ class Logging(commands.Cog, logging.Handler):
             try:
                 msg = self.format(record)
                 try:
-                    await channel.send(embed=discord_common.embed_failed_command(record))
+                    await channel.send(
+                        embed=discord_common.embed_failed_command(record))
                 except AttributeError:
                     pass
                 discord_msg_char_limit = 2000

--- a/tle/cogs/logging.py
+++ b/tle/cogs/logging.py
@@ -24,7 +24,7 @@ class Logging(commands.Cog, logging.Handler):
     async def on_ready(self):
         self.task = asyncio.create_task(self._log_task())
         width = 79
-        stars, msg = f'`{"*" * width}`', f'`***{"Bot running":^{width - 6}}***`'
+        stars, msg = f'{"*" * width}', f'***{"Bot running":^{width - 6}}***'
         self.logger.log(level=100, msg=stars)
         self.logger.log(level=100, msg=msg)
         self.logger.log(level=100, msg=stars)
@@ -40,7 +40,17 @@ class Logging(commands.Cog, logging.Handler):
                 break
             try:
                 msg = self.format(record)
-                await channel.send(msg)
+                try:
+                    await channel.send(embed=discord_common.embed_failed_command(record))
+                except AttributeError:
+                    pass
+                discord_msg_char_limit = 2000
+                char_limit = discord_msg_char_limit - 2 * len('```')
+                too_long = len(msg) > char_limit
+                msg = msg[:char_limit]
+                await channel.send('```{}```'.format(msg))
+                if too_long:
+                    await channel.send('`Check logs for full stack trace`')
             except:
                 self.handleError(record)
 

--- a/tle/util/discord_common.py
+++ b/tle/util/discord_common.py
@@ -40,7 +40,7 @@ def cf_color_embed(**kwargs):
 def set_same_cf_color(embeds):
     color = random_cf_color()
     for embed in embeds:
-        embed.color= color
+        embed.color=color
 
 
 def attach_image(embed, img_file):

--- a/tle/util/discord_common.py
+++ b/tle/util/discord_common.py
@@ -40,7 +40,7 @@ def cf_color_embed(**kwargs):
 def set_same_cf_color(embeds):
     color = random_cf_color()
     for embed in embeds:
-        embed.color = color
+        embed.color= color
 
 
 def attach_image(embed, img_file):
@@ -125,7 +125,7 @@ async def presence(bot):
     await asyncio.sleep(60)
 
     @tasks.task(name='OrzUpdate',
-                waiter=tasks.Waiter.fixed_delay(5*60))
+               waiter=tasks.Waiter.fixed_delay(5*60))
     async def presence_task(_):
         while True:
             target = random.choice([

--- a/tle/util/discord_common.py
+++ b/tle/util/discord_common.py
@@ -29,25 +29,18 @@ def embed_alert(desc):
     return discord.Embed(description=str(desc), color=_ALERT_AMBER)
 
 
-def embed_failed_command(record):
-    return discord.Embed().add_field(name='Original Command:',
-                                     value=record.message_content,
-                                     inline=False).add_field(
-                                         name='Jump Link:',
-                                         value=record.jump_url,
-                                         inline=False)
-
-
 def random_cf_color():
     return random.choice(_CF_COLORS)
+
 
 def cf_color_embed(**kwargs):
     return discord.Embed(**kwargs, color=random_cf_color())
 
+
 def set_same_cf_color(embeds):
     color = random_cf_color()
     for embed in embeds:
-        embed.color=color
+        embed.color = color
 
 
 def attach_image(embed, img_file):
@@ -92,16 +85,17 @@ async def bot_error_handler(ctx, exception):
         exc_info = type(exception), exception, exception.__traceback__
         logger.exception('Ignoring exception in command {}:'.format(
             ctx.command),
-                         exc_info=exc_info,
-                         extra={
-                             "message_content": ctx.message.content,
-                             "jump_url": ctx.message.jump_url
-                         })
+            exc_info=exc_info,
+            extra={
+            "message_content": ctx.message.content,
+            "jump_url": ctx.message.jump_url
+        })
 
 
 def once(func):
     """Decorator that wraps the given async function such that it is executed only once."""
     first = True
+
     @functools.wraps(func)
     async def wrapper(*args, **kwargs):
         nonlocal first
@@ -132,7 +126,7 @@ async def presence(bot):
     await asyncio.sleep(60)
 
     @tasks.task(name='OrzUpdate',
-               waiter=tasks.Waiter.fixed_delay(5*60))
+                waiter=tasks.Waiter.fixed_delay(5*60))
     async def presence_task(_):
         while True:
             target = random.choice([

--- a/tle/util/discord_common.py
+++ b/tle/util/discord_common.py
@@ -82,14 +82,13 @@ async def bot_error_handler(ctx, exception):
     elif isinstance(exception, (cf.CodeforcesApiError, commands.UserInputError)):
         await ctx.send(embed=embed_alert(exception))
     else:
+        msg = 'Ignoring exception in command {}:'.format(ctx.command)
         exc_info = type(exception), exception, exception.__traceback__
-        logger.exception('Ignoring exception in command {}:'.format(
-            ctx.command),
-            exc_info=exc_info,
-            extra={
+        extra = {
             "message_content": ctx.message.content,
             "jump_url": ctx.message.jump_url
-        })
+        }
+        logger.exception(msg, exc_info=exc_info, extra=extra)
 
 
 def once(func):

--- a/tle/util/discord_common.py
+++ b/tle/util/discord_common.py
@@ -28,6 +28,11 @@ def embed_success(desc):
 def embed_alert(desc):
     return discord.Embed(description=str(desc), color=_ALERT_AMBER)
 
+def embed_failed_command(record):
+    return discord.Embed().add_field(name='Original Command:',
+			value=record.message_content,inline=False).add_field(name='Jump Link:',
+			value=record.jump_url,inline=False)
+
 def random_cf_color():
     return random.choice(_CF_COLORS)
 
@@ -80,7 +85,7 @@ async def bot_error_handler(ctx, exception):
         await ctx.send(embed=embed_alert(exception))
     else:
         exc_info = type(exception), exception, exception.__traceback__
-        logger.exception('Ignoring exception in command {}:'.format(ctx.command), exc_info=exc_info)
+        logger.exception('Ignoring exception in command {}:'.format(ctx.command), exc_info=exc_info, extra={"message_content": ctx.message.content, "jump_url":ctx.message.jump_url})
 
 
 def once(func):

--- a/tle/util/discord_common.py
+++ b/tle/util/discord_common.py
@@ -28,10 +28,15 @@ def embed_success(desc):
 def embed_alert(desc):
     return discord.Embed(description=str(desc), color=_ALERT_AMBER)
 
+
 def embed_failed_command(record):
     return discord.Embed().add_field(name='Original Command:',
-			value=record.message_content,inline=False).add_field(name='Jump Link:',
-			value=record.jump_url,inline=False)
+                                     value=record.message_content,
+                                     inline=False).add_field(
+                                         name='Jump Link:',
+                                         value=record.jump_url,
+                                         inline=False)
+
 
 def random_cf_color():
     return random.choice(_CF_COLORS)
@@ -85,7 +90,13 @@ async def bot_error_handler(ctx, exception):
         await ctx.send(embed=embed_alert(exception))
     else:
         exc_info = type(exception), exception, exception.__traceback__
-        logger.exception('Ignoring exception in command {}:'.format(ctx.command), exc_info=exc_info, extra={"message_content": ctx.message.content, "jump_url":ctx.message.jump_url})
+        logger.exception('Ignoring exception in command {}:'.format(
+            ctx.command),
+                         exc_info=exc_info,
+                         extra={
+                             "message_content": ctx.message.content,
+                             "jump_url": ctx.message.jump_url
+                         })
 
 
 def once(func):
@@ -133,4 +144,3 @@ async def presence(bot):
             await asyncio.sleep(10 * 60)
 
     presence_task.start()
-


### PR DESCRIPTION
This change

- Wraps logging output in a code block to prevent discord formatting on tracebacks.
- Adds embed for link and command that caused an exception.
- Remove logging from ;cache command because it double logged to channel where the command was sent, and in logging channel.
- Remove code block formatting from logging start up.

Fixes #404 

**Before**:
<img width="1085" alt="image" src="https://user-images.githubusercontent.com/8847876/104960073-6e60c180-59cb-11eb-8a6d-a4ee29adf1d3.png">
<img width="1102" alt="image" src="https://user-images.githubusercontent.com/8847876/104956496-238f7b80-59c4-11eb-88f5-4f4e0b283c5f.png">
**After**:
<img width="981" alt="image" src="https://user-images.githubusercontent.com/8847876/104959910-2477db80-59cb-11eb-86c6-d6533b2f8c0b.png">
<img width="985" alt="image" src="https://user-images.githubusercontent.com/8847876/104957117-7289e080-59c5-11eb-8456-339ca3a2b717.png">
