### PR TITLE
Fix bug in ;plot scatter command

### DIFF
--- a/tle/cogs/graphs.py
+++ b/tle/cogs/graphs.py
@@ -550,7 +550,7 @@ class Graphs(commands.Cog):
         if legend:
             plt.legend(labels, loc='upper left')
         _plot_average(practice, bin_size)
-        _plot_rating(rating_resp, mark='')
+        _plot_rating_by_date(rating_resp, mark='')
 
         # zoom
         ymin, ymax = plt.gca().get_ylim()


### PR DESCRIPTION
This Pull Request fixes the `;plot scatter` command, which stopped working (apparently after the last code changes introduced on https://github.com/cheran-senthil/TLE/pull/482)

Error logs before applying this code fix
```py
tle.util.discord_common:Ignoring exception in command plot scatter:
Jan 26 22:49:32 discord-bots run.sh[147522]: Traceback (most recent call last):
Jan 26 22:49:32 discord-bots run.sh[147522]:   File "/root/.cache/pypoetry/virtualenvs/tle-M6DtSVNE-py3.8/lib/python3.8/site-packages/discord/ext/commands/core.py", line 85, in wrapped
Jan 26 22:49:32 discord-bots run.sh[147522]:     ret = await coro(*args, **kwargs)
Jan 26 22:49:32 discord-bots run.sh[147522]:   File "/home/orendon/discord/TLE/tle/cogs/graphs.py", line 553, in scatter
Jan 26 22:49:32 discord-bots run.sh[147522]:     _plot_rating(rating_resp, mark='')
Jan 26 22:49:32 discord-bots run.sh[147522]:   File "/home/orendon/discord/TLE/tle/cogs/graphs.py", line 43, in _plot_rating
Jan 26 22:49:32 discord-bots run.sh[147522]:     for ratings, when in plot_data:
Jan 26 22:49:32 discord-bots run.sh[147522]: ValueError: too many values to unpack (expected 2)
```