### PR TITLE
Add tags to duel

### DIFF
--- a/tle/cogs/codeforces.py
+++ b/tle/cogs/codeforces.py
@@ -108,10 +108,9 @@ class Codeforces(commands.Cog):
         solved = {sub.problem.name for sub in submissions if sub.verdict == 'OK'}
 
         problems = [prob for prob in cf_common.cache2.problem_cache.problems
-                    if prob.rating == rating and prob.name not in solved and
-                    not cf_common.is_contest_writer(prob.contestId, handle)]
-        if tags:
-            problems = [prob for prob in problems if prob.matches_tags(tags)]
+                    if prob.rating == rating and prob.name not in solved 
+                    and not cf_common.is_contest_writer(prob.contestId, handle)
+                    and prob.matches_tags(tags)]
 
         if not problems:
             raise CodeforcesCogError('Problems not found within the search parameters')
@@ -188,9 +187,8 @@ class Codeforces(commands.Cog):
         problems = [prob for prob in cf_common.cache2.problem_cache.problems
                     if abs(prob.rating - rating) <= 100 and prob.name not in solved
                     and not any(cf_common.is_contest_writer(prob.contestId, handle) for handle in handles)
-                    and not cf_common.is_nonstandard_problem(prob)]
-        if tags:
-            problems = [prob for prob in problems if prob.matches_tags(tags)]
+                    and not cf_common.is_nonstandard_problem(prob)
+                    and prob.matches_tags(args)]
 
         if len(problems) < 4:
             raise CodeforcesCogError('Problems not found within the search parameters')

--- a/tle/cogs/codeforces.py
+++ b/tle/cogs/codeforces.py
@@ -110,7 +110,7 @@ class Codeforces(commands.Cog):
         problems = [prob for prob in cf_common.cache2.problem_cache.problems
                     if prob.rating == rating and prob.name not in solved 
                     and not cf_common.is_contest_writer(prob.contestId, handle)
-                    and prob.matches_tags(tags)]
+                    and prob.matching_tags(tags)]
 
         if not problems:
             raise CodeforcesCogError('Problems not found within the search parameters')
@@ -126,7 +126,7 @@ class Codeforces(commands.Cog):
         embed = discord.Embed(title=title, url=problem.url, description=desc)
         embed.add_field(name='Rating', value=problem.rating)
         if tags:
-            tagslist = ', '.join(problem.matches_tags(tags))
+            tagslist = ', '.join(problem.matching_tags(tags))
             embed.add_field(name='Matched tags', value=tagslist)
         await ctx.send(f'Recommended problem for `{handle}`', embed=embed)
 
@@ -188,7 +188,7 @@ class Codeforces(commands.Cog):
                     if abs(prob.rating - rating) <= 100 and prob.name not in solved
                     and not any(cf_common.is_contest_writer(prob.contestId, handle) for handle in handles)
                     and not cf_common.is_nonstandard_problem(prob)
-                    and prob.matches_tags(tags)]
+                    and prob.matching_tags(tags)]
 
         if len(problems) < 4:
             raise CodeforcesCogError('Problems not found within the search parameters')

--- a/tle/cogs/codeforces.py
+++ b/tle/cogs/codeforces.py
@@ -188,7 +188,7 @@ class Codeforces(commands.Cog):
                     if abs(prob.rating - rating) <= 100 and prob.name not in solved
                     and not any(cf_common.is_contest_writer(prob.contestId, handle) for handle in handles)
                     and not cf_common.is_nonstandard_problem(prob)
-                    and prob.matches_tags(args)]
+                    and prob.matches_tags(tags)]
 
         if len(problems) < 4:
             raise CodeforcesCogError('Problems not found within the search parameters')

--- a/tle/cogs/codeforces.py
+++ b/tle/cogs/codeforces.py
@@ -113,7 +113,7 @@ class Codeforces(commands.Cog):
                     and prob.matches_tags(tags)]
 
         if not problems:
-            raise CodeforcesCogError('Problems not found within the search parameters')
+            raise CodeforcesCogError('Problems not found within the search parameters ('+' '.join(tags)+')')
 
         problems.sort(key=lambda problem: cf_common.cache2.contest_cache.get_contest(
             problem.contestId).startTimeSeconds)

--- a/tle/cogs/codeforces.py
+++ b/tle/cogs/codeforces.py
@@ -378,7 +378,7 @@ class Codeforces(commands.Cog):
         """Displays a list of contests, sorted by number of unsolved problems.
         Contest names matching any of the provided tags will be considered. e.g ;fullsolve +edu"""
         handle, = await cf_common.resolve_handles(ctx, self.converter, ('!' + str(ctx.author),))
-        tags = cf_common.parse_tags(args)
+        tags = [x for x in args if x[0] == '+']
 
         problem_to_contests = cf_common.cache2.problemset_cache.problem_to_contests
         contests = [contest for contest in cf_common.cache2.contest_cache.get_contests_in_phase('FINISHED')

--- a/tle/cogs/codeforces.py
+++ b/tle/cogs/codeforces.py
@@ -113,7 +113,7 @@ class Codeforces(commands.Cog):
                     and prob.matches_tags(tags)]
 
         if not problems:
-            raise CodeforcesCogError('Problems not found within the search parameters ('+' '.join(tags)+')')
+            raise CodeforcesCogError('Problems not found within the search parameters')
 
         problems.sort(key=lambda problem: cf_common.cache2.contest_cache.get_contest(
             problem.contestId).startTimeSeconds)

--- a/tle/cogs/codeforces.py
+++ b/tle/cogs/codeforces.py
@@ -110,7 +110,7 @@ class Codeforces(commands.Cog):
         problems = [prob for prob in cf_common.cache2.problem_cache.problems
                     if prob.rating == rating and prob.name not in solved 
                     and not cf_common.is_contest_writer(prob.contestId, handle)
-                    and prob.matching_tags(tags)]
+                    and prob.matches_all_tags(tags)]
 
         if not problems:
             raise CodeforcesCogError('Problems not found within the search parameters')
@@ -126,7 +126,7 @@ class Codeforces(commands.Cog):
         embed = discord.Embed(title=title, url=problem.url, description=desc)
         embed.add_field(name='Rating', value=problem.rating)
         if tags:
-            tagslist = ', '.join(problem.matching_tags(tags))
+            tagslist = ', '.join(problem.get_matched_tags(tags))
             embed.add_field(name='Matched tags', value=tagslist)
         await ctx.send(f'Recommended problem for `{handle}`', embed=embed)
 
@@ -188,7 +188,7 @@ class Codeforces(commands.Cog):
                     if abs(prob.rating - rating) <= 100 and prob.name not in solved
                     and not any(cf_common.is_contest_writer(prob.contestId, handle) for handle in handles)
                     and not cf_common.is_nonstandard_problem(prob)
-                    and prob.matching_tags(tags)]
+                    and prob.matches_all_tags(tags)]
 
         if len(problems) < 4:
             raise CodeforcesCogError('Problems not found within the search parameters')

--- a/tle/cogs/duel.py
+++ b/tle/cogs/duel.py
@@ -129,9 +129,9 @@ class Dueling(commands.Cog):
                 f'{ctx.author.mention} is already a registered duelist')
         await ctx.send(f'{ctx.author.mention} successfully registered as a duelist')
 
-    @duel.command(brief='Challenge to a duel')
+    @duel.command(brief='Challenge to a duel', usage='opponent [rating] [+tags]')
     async def challenge(self, ctx, opponent: discord.Member, *args):
-        """Challenge another server member to a duel. Problem difficulty will be the lesser of duelist ratings minus 400. You can alternatively specify a different rating. The duel will be unrated if specified rating is above the default value. The challenge expires if ignored for 5 minutes."""
+        """Challenge another server member to a duel. Problem difficulty will be the lesser of duelist ratings minus 400. You can alternatively specify a different rating. The duel will be unrated if specified rating is above the default value or tags are used to choose a problem. The challenge expires if ignored for 5 minutes."""
         challenger_id = ctx.author.id
         challengee_id = opponent.id
 
@@ -157,7 +157,6 @@ class Dueling(commands.Cog):
             raise DuelCogError(
                 f'{opponent.mention} is currently in a duel!')
         tags  = []
-        notags= []
         rating=None
         
         for arg in args:

--- a/tle/cogs/duel.py
+++ b/tle/cogs/duel.py
@@ -156,16 +156,10 @@ class Dueling(commands.Cog):
         if cf_common.user_db.check_duel_challenge(challengee_id):
             raise DuelCogError(
                 f'{opponent.mention} is currently in a duel!')
-        tags  = []
-        rating=None
-        
-        for arg in args:
-            if arg[0] == '+':
-                tags.append(arg[1:])
-            else:
-                if arg.isdigit():
-                    rating = int(arg)                
-
+                
+         
+        tags = cf_common.parse_tags(args)
+        rating = cf_common.parse_rating(args, None)
         users = [cf_common.user_db.fetch_cf_user(handle) for handle in handles]
         lowest_rating = min(user.rating or 0 for user in users)
         suggested_rating = max(
@@ -184,7 +178,7 @@ class Dueling(commands.Cog):
                     if prob.rating == rating and prob.name not in solved and prob.name not in seen
                     and not any(cf_common.is_contest_writer(prob.contestId, handle) for handle in handles)
                     and not cf_common.is_nonstandard_problem(prob)
-                    and prob.tag_matches(tags)]                                              
+                    and prob.matches_tags(tags)]                                              
 
         for problems in map(get_problems, range(rating, 400, -100)):
             if problems:

--- a/tle/cogs/duel.py
+++ b/tle/cogs/duel.py
@@ -177,7 +177,7 @@ class Dueling(commands.Cog):
                     if prob.rating == rating and prob.name not in solved and prob.name not in seen
                     and not any(cf_common.is_contest_writer(prob.contestId, handle) for handle in handles)
                     and not cf_common.is_nonstandard_problem(prob)
-                    and prob.matching_tags(tags)]
+                    and prob.matches_all_tags(tags)]
 
         for problems in map(get_problems, range(rating, 400, -100)):
             if problems:

--- a/tle/cogs/duel.py
+++ b/tle/cogs/duel.py
@@ -157,7 +157,6 @@ class Dueling(commands.Cog):
             raise DuelCogError(
                 f'{opponent.mention} is currently in a duel!')
                 
-         
         tags = cf_common.parse_tags(args)
         rating = cf_common.parse_rating(args, None)
         users = [cf_common.user_db.fetch_cf_user(handle) for handle in handles]
@@ -178,7 +177,7 @@ class Dueling(commands.Cog):
                     if prob.rating == rating and prob.name not in solved and prob.name not in seen
                     and not any(cf_common.is_contest_writer(prob.contestId, handle) for handle in handles)
                     and not cf_common.is_nonstandard_problem(prob)
-                    and prob.matches_tags(tags)]                                              
+                    and prob.matches_tags(tags)]
 
         for problems in map(get_problems, range(rating, 400, -100)):
             if problems:

--- a/tle/cogs/duel.py
+++ b/tle/cogs/duel.py
@@ -158,7 +158,7 @@ class Dueling(commands.Cog):
                 f'{opponent.mention} is currently in a duel!')
                 
         tags = cf_common.parse_tags(args)
-        rating = cf_common.parse_rating(args, None)
+        rating = cf_common.parse_rating(args)
         users = [cf_common.user_db.fetch_cf_user(handle) for handle in handles]
         lowest_rating = min(user.rating or 0 for user in users)
         suggested_rating = max(
@@ -177,7 +177,7 @@ class Dueling(commands.Cog):
                     if prob.rating == rating and prob.name not in solved and prob.name not in seen
                     and not any(cf_common.is_contest_writer(prob.contestId, handle) for handle in handles)
                     and not cf_common.is_nonstandard_problem(prob)
-                    and prob.matches_tags(tags)]
+                    and prob.matching_tags(tags)]
 
         for problems in map(get_problems, range(rating, 400, -100)):
             if problems:

--- a/tle/util/codeforces_api.py
+++ b/tle/util/codeforces_api.py
@@ -116,8 +116,10 @@ class Problem(namedtuple('Problem', 'contestId problemsetName index name type po
     def has_metadata(self):
         return self.contestId is not None and self.rating is not None
 
-    def tag_matches(self, query_tags):
+    def matches_tags(self, query_tags):
         """If every query tag is a substring of any problem tag, returns a list of matched tags."""
+        if len(query_tags) == 0:
+            return self.tags
         matches = set()
         for query_tag in query_tags:
             curmatch = [tag for tag in self.tags if query_tag in tag]

--- a/tle/util/codeforces_api.py
+++ b/tle/util/codeforces_api.py
@@ -116,16 +116,26 @@ class Problem(namedtuple('Problem', 'contestId problemsetName index name type po
     def has_metadata(self):
         return self.contestId is not None and self.rating is not None
 
-    def matching_tags(self, filter_tags):
-        """Function checks if every filter tag is a substring of any problem tag. If all filter tags can be matched it returns a list of matched tags. Otherwise the result is None. 
-        If function is called with no filter_tags it returns all problem tags. This allows the function to be used in a natural way even if no filter tags are set."""
-        if not filter_tags:
-            return self.tags
+    def matching_tags(self, match_tags):
+        """Function tries to match every match_tag to a problem tag. A match is valid if the match_tag is a substring of any problem tag. 
+        The function returns the number of successfully matched tags."""
+        count = 0
+        for match_tag in match_tags:
+            curmatch = [tag for tag in self.tags if match_tag in tag]
+            if curmatch:
+                count += 1
+        return count
+
+    def matches_all_tags(self, match_tags):
+        return self.matching_tags(match_tags) == len(match_tags)
+
+    def matches_any_tag(self, match_tags):
+        return self.matching_tags(match_tags) > 0
+
+    def get_matched_tags(self, match_tags):
         matches = set()
-        for query_tag in filter_tags:
-            curmatch = [tag for tag in self.tags if query_tag in tag]
-            if not curmatch:
-                return None
+        for match_tag in match_tags:
+            curmatch = [tag for tag in self.tags if match_tag in tag]
             matches.update(curmatch)
         return list(matches)
 

--- a/tle/util/codeforces_api.py
+++ b/tle/util/codeforces_api.py
@@ -116,12 +116,13 @@ class Problem(namedtuple('Problem', 'contestId problemsetName index name type po
     def has_metadata(self):
         return self.contestId is not None and self.rating is not None
 
-    def matches_tags(self, query_tags):
-        """If every query tag is a substring of any problem tag, returns a list of matched tags."""
-        if len(query_tags) == 0:
+    def matching_tags(self, filter_tags):
+        """Function checks if every filter tag is a substring of any problem tag. If all filter tags can be matched it returns a list of matched tags. Otherwise the result is None. 
+        If function is called with no filter_tags it returns all problem tags. This allows the function to be used in a natural way even if no filter tags are set."""
+        if not filter_tags:
             return self.tags
         matches = set()
-        for query_tag in query_tags:
+        for query_tag in filter_tags:
             curmatch = [tag for tag in self.tags if query_tag in tag]
             if not curmatch:
                 return None

--- a/tle/util/codeforces_common.py
+++ b/tle/util/codeforces_common.py
@@ -108,7 +108,7 @@ def is_nonstandard_contest(contest):
 
 def is_nonstandard_problem(problem):
     return (is_nonstandard_contest(cache2.contest_cache.get_contest(problem.contestId)) or
-            problem.matching_tags(['*special']))
+            problem.matches_all_tags(['*special']))
 
 
 async def get_visited_contests(handles : [str]):
@@ -373,7 +373,7 @@ class SubFilter:
             contest = cache2.contest_cache.contest_by_id.get(problem.contestId, None)
             type_ok = submission.author.participantType in self.types
             date_ok = self.dlo <= submission.creationTimeSeconds < self.dhi
-            tag_ok = problem.matching_tags(self.tags)
+            tag_ok = problem.matches_all_tags(self.tags)
             index_ok = not self.indices or any(index.lower() == problem.index.lower() for index in self.indices)
             contest_ok = not self.contests or (contest and contest.matches(self.contests))
             team_ok = self.team or len(submission.author.members) == 1

--- a/tle/util/codeforces_common.py
+++ b/tle/util/codeforces_common.py
@@ -371,7 +371,7 @@ class SubFilter:
             contest = cache2.contest_cache.contest_by_id.get(problem.contestId, None)
             type_ok = submission.author.participantType in self.types
             date_ok = self.dlo <= submission.creationTimeSeconds < self.dhi
-            tag_ok = not self.tags or problem.matches_tags(self.tags)
+            tag_ok = problem.matches_tags(self.tags)
             index_ok = not self.indices or any(index.lower() == problem.index.lower() for index in self.indices)
             contest_ok = not self.contests or (contest and contest.matches(self.contests))
             team_ok = self.team or len(submission.author.members) == 1

--- a/tle/util/codeforces_common.py
+++ b/tle/util/codeforces_common.py
@@ -279,16 +279,19 @@ def parse_date(arg):
         return time.mktime(datetime.datetime.strptime(arg, fmt).timetuple())
     except ValueError:
         raise ParamParseError(f'{arg} is an invalid date argument')
-        
+
+
 def parse_tags(args):
     tags = [x[1:] for x in args if x[0] == '+']
     return tags
-    
+
+
 def parse_rating(args, default_value):
     for arg in args:
         if arg.isdigit():
             return int(arg)
     return default_value
+
 
 class SubFilter:
     def __init__(self, rated=True):

--- a/tle/util/codeforces_common.py
+++ b/tle/util/codeforces_common.py
@@ -108,7 +108,7 @@ def is_nonstandard_contest(contest):
 
 def is_nonstandard_problem(problem):
     return (is_nonstandard_contest(cache2.contest_cache.get_contest(problem.contestId)) or
-            problem.tag_matches(['*special']))
+            problem.matches_tags(['*special']))
 
 
 async def get_visited_contests(handles : [str]):
@@ -279,6 +279,17 @@ def parse_date(arg):
         return time.mktime(datetime.datetime.strptime(arg, fmt).timetuple())
     except ValueError:
         raise ParamParseError(f'{arg} is an invalid date argument')
+        
+def parse_tags(args):
+    tags = [x for x in args if x[0] == '+']
+    return tags
+    
+def parse_rating(args, default_value):
+    rating = default_value
+    for arg in args:
+        if arg.isdigit():
+            rating = int(arg)
+    return rating
 
 class SubFilter:
     def __init__(self, rated=True):
@@ -360,7 +371,7 @@ class SubFilter:
             contest = cache2.contest_cache.contest_by_id.get(problem.contestId, None)
             type_ok = submission.author.participantType in self.types
             date_ok = self.dlo <= submission.creationTimeSeconds < self.dhi
-            tag_ok = not self.tags or problem.tag_matches(self.tags)
+            tag_ok = not self.tags or problem.matches_tags(self.tags)
             index_ok = not self.indices or any(index.lower() == problem.index.lower() for index in self.indices)
             contest_ok = not self.contests or (contest and contest.matches(self.contests))
             team_ok = self.team or len(submission.author.members) == 1

--- a/tle/util/codeforces_common.py
+++ b/tle/util/codeforces_common.py
@@ -285,11 +285,10 @@ def parse_tags(args):
     return tags
     
 def parse_rating(args, default_value):
-    rating = default_value
     for arg in args:
         if arg.isdigit():
-            rating = int(arg)
-    return rating
+            return int(arg)
+    return default_value
 
 class SubFilter:
     def __init__(self, rated=True):

--- a/tle/util/codeforces_common.py
+++ b/tle/util/codeforces_common.py
@@ -281,7 +281,7 @@ def parse_date(arg):
         raise ParamParseError(f'{arg} is an invalid date argument')
         
 def parse_tags(args):
-    tags = [x for x in args if x[0] == '+']
+    tags = [x[1:] for x in args if x[0] == '+']
     return tags
     
 def parse_rating(args, default_value):

--- a/tle/util/codeforces_common.py
+++ b/tle/util/codeforces_common.py
@@ -108,7 +108,7 @@ def is_nonstandard_contest(contest):
 
 def is_nonstandard_problem(problem):
     return (is_nonstandard_contest(cache2.contest_cache.get_contest(problem.contestId)) or
-            problem.matches_tags(['*special']))
+            problem.matching_tags(['*special']))
 
 
 async def get_visited_contests(handles : [str]):
@@ -286,7 +286,7 @@ def parse_tags(args):
     return tags
 
 
-def parse_rating(args, default_value):
+def parse_rating(args, default_value = None):
     for arg in args:
         if arg.isdigit():
             return int(arg)
@@ -373,7 +373,7 @@ class SubFilter:
             contest = cache2.contest_cache.contest_by_id.get(problem.contestId, None)
             type_ok = submission.author.participantType in self.types
             date_ok = self.dlo <= submission.creationTimeSeconds < self.dhi
-            tag_ok = problem.matches_tags(self.tags)
+            tag_ok = problem.matching_tags(self.tags)
             index_ok = not self.indices or any(index.lower() == problem.index.lower() for index in self.indices)
             contest_ok = not self.contests or (contest and contest.matches(self.contests))
             team_ok = self.team or len(submission.author.members) == 1


### PR DESCRIPTION
As discussed: Base functionality for using duel with tags. It is possible to add more than one tag. Duels that use tags to choose the problem are declared inofficial.