### PR TITLE
Fix _resolve_redirect for unmagic requests

### DIFF
--- a/tle/util/codeforces_api.py
+++ b/tle/util/codeforces_api.py
@@ -453,7 +453,7 @@ async def _needs_fixing(handles):
 
 
 async def _resolve_redirect(handle):
-    url = 'http://codeforces.com/profile/' + handle
+    url = PROFILE_BASE_URL + handle
     async with _session.head(url) as r:
         if r.status == 200:
             return handle


### PR DESCRIPTION
## **Summary** 
**Problem**: `;handle unmagic` is throwing an error
**Solution**: Update the `_resolve_redirect` function to use `https` instead of `http`

## **Details**

The following error is received when attempting to use the `unmagic` command after changing your username with new years magic
```
Something went wrong trying to redirect http://codeforces.com/profile/OldUsername
```

Checking the function here we see the error was thrown on line 466-467: https://github.com/cheran-senthil/TLE/blob/b3f93b11db3a7c4e08e694bdcff2e7163b7e6763/tle/util/codeforces_api.py#L455-L467

We can see that if we don't get a `200` or `302` response from the server, then that error will be thrown.

Checking the url from the above code using `curl` gives us the following response:
```
$ curl http://codeforces.com/profile/OldUsername -i
HTTP/1.1 301 Moved Permanently
Server: kittenx
Date: ------
Content-Type: text/html
Content-Length: 164
Connection: keep-alive
Location: https://codeforces.com/profile/OldUsername
```
We get a `301 Moved Permanently` response, redirecting us to the `https` version of the page. This results in the previously mentioned error (since we got a `301` instead of `200` or `302`)

Checking the `https` version we get the correct `302` response
```
$ curl https://codeforces.com/profile/OldUsername -i
HTTP/2 302
server: kittenx
date: ------
content-type: text/html;charset=UTF-8
content-length: 0
location: https://codeforces.com/profile/NewUsername
```
