### PR TITLE
Add support for +official flag in ranklist

### DIFF
--- a/tle/cogs/contests.py
+++ b/tle/cogs/contests.py
@@ -460,7 +460,7 @@ class Contests(commands.Cog):
             if contest.phase == 'BEFORE':
                 raise ContestCogError(f'Contest `{contest.id} | {contest.name}` has not started')
             ranklist = await cf_common.cache2.ranklist_cache.generate_ranklist(contest.id, fetch_changes=True,
-                                                                               show_unofficial=show_official is False)
+                                                                               show_unofficial=not show_official)
 
         await wait_msg.delete()
         await ctx.channel.send(embed=self._make_contest_embed_for_ranklist(ranklist))
@@ -479,7 +479,7 @@ class Contests(commands.Cog):
                 continue
 
             # Database has correct handle ignoring case, update to it
-            handle = standing.party.teamName or standing.party.members[0].handle
+            handle = rl.Ranklist.get_ranklist_lookup_key(standing)
             if vc and standing.party.participantType != 'VIRTUAL':
                 continue
             handle_standings.append((handle, standing))

--- a/tle/cogs/contests.py
+++ b/tle/cogs/contests.py
@@ -442,21 +442,26 @@ class Contests(commands.Cog):
         return embed
 
     @commands.command(brief='Show ranklist for given handles and/or server members')
-    async def ranklist(self, ctx, contest_id: int, *handles: str):
-        """Shows ranklist for the contest with given contest id. If handles contains
-        '+server', all server members are included. No handles defaults to '+server'.
+    async def ranklist(self, ctx, contest_id: int, *args: str):
         """
-        handles = await cf_common.resolve_handles(ctx, self.member_converter, handles, maxcnt=None, default_to_all_server=True)
+        Shows ranklist for the contest with given contest id. If handles contains
+        '+server', all server members are included. No handles defaults to '+server'.
+        Use '+official' for only showing rated participants for the round
+        """
+        (show_official,), handles = cf_common.filter_flags(args, ['+official'])
+        handles = await cf_common.resolve_handles(ctx, self.member_converter, handles, maxcnt=None,
+                                                  default_to_all_server=True)
         contest = cf_common.cache2.contest_cache.get_contest(contest_id)
         wait_msg = await ctx.channel.send('Generating ranklist, please wait...')
         ranklist = None
         try:
-            ranklist = cf_common.cache2.ranklist_cache.get_ranklist(contest)
+            ranklist = cf_common.cache2.ranklist_cache.get_ranklist(contest, show_official)
         except cache_system2.RanklistNotMonitored:
             if contest.phase == 'BEFORE':
                 raise ContestCogError(f'Contest `{contest.id} | {contest.name}` has not started')
-            ranklist = await cf_common.cache2.ranklist_cache.generate_ranklist(contest.id,
-                                                                            fetch_changes=True)
+            ranklist = await cf_common.cache2.ranklist_cache.generate_ranklist(contest.id, fetch_changes=True,
+                                                                               show_unofficial=show_official is False)
+
         await wait_msg.delete()
         await ctx.channel.send(embed=self._make_contest_embed_for_ranklist(ranklist))
         await self._show_ranklist(channel=ctx.channel, contest_id=contest_id, handles=handles, ranklist=ranklist)
@@ -474,9 +479,7 @@ class Contests(commands.Cog):
                 continue
 
             # Database has correct handle ignoring case, update to it
-            # TODO: It will throw an exception if this row corresponds to a team. At present ranklist doesnt show teams.
-            # It should be fixed in https://github.com/cheran-senthil/TLE/issues/72
-            handle = standing.party.members[0].handle
+            handle = standing.party.teamName or standing.party.members[0].handle
             if vc and standing.party.participantType != 'VIRTUAL':
                 continue
             handle_standings.append((handle, standing))

--- a/tle/util/cache_system2.py
+++ b/tle/util/cache_system2.py
@@ -17,8 +17,10 @@ logger = logging.getLogger(__name__)
 _CONTESTS_PER_BATCH_IN_CACHE_UPDATES = 100
 CONTEST_BLACKLIST = {1308, 1309, 1431, 1432}
 
+
 def _is_blacklisted(contest):
     return contest.id in CONTEST_BLACKLIST
+
 
 class CacheError(commands.CommandError):
     pass
@@ -419,11 +421,11 @@ class RatingChangesCache:
 
         to_monitor = [
             contest for contest in
-            self.cache_master.contest_cache.contests_by_phase['FINISHED'] 
+            self.cache_master.contest_cache.contests_by_phase['FINISHED']
             if self.is_newly_finished_without_rating_changes(contest)
-            and not _is_blacklisted(contest)
-            ]
-                 
+               and not _is_blacklisted(contest)
+        ]
+
         cur_ids = {contest.id for contest in self.monitored_contests}
         new_ids = {contest.id for contest in to_monitor}
         if new_ids != cur_ids:
@@ -440,7 +442,7 @@ class RatingChangesCache:
         self.monitored_contests = [
             contest for contest in self.monitored_contests
             if self.is_newly_finished_without_rating_changes(contest)
-            and not _is_blacklisted(contest)
+               and not _is_blacklisted(contest)
         ]
 
         if not self.monitored_contests:
@@ -515,6 +517,7 @@ class RanklistNotMonitored(RanklistCacheError):
         super().__init__(f'The ranklist for `{contest.name}` is not being monitored')
         self.contest = contest
 
+
 class RanklistCache:
     _RELOAD_DELAY = 2 * 60
 
@@ -527,11 +530,12 @@ class RanklistCache:
     async def run(self):
         self._update_task.start()
 
-    def get_ranklist(self, contest):
-        try:
-            return self.ranklist_by_contest[contest.id]
-        except KeyError:
+    # Currently ranklist monitoring only supports caching unofficial ranklists
+    # If official ranklist is asked, the cache will throw RanklistNotMonitored Error
+    def get_ranklist(self, contest, show_official):
+        if show_official or contest.id not in self.ranklist_by_contest:
             raise RanklistNotMonitored(contest)
+        return self.ranklist_by_contest[contest.id]
 
     @tasks.task_spec(name='RanklistCacheUpdate',
                      waiter=tasks.Waiter.for_event(events.ContestListRefresh))
@@ -543,7 +547,7 @@ class RanklistCache:
         finished_contests = [
             contest for contest in contests_by_phase['FINISHED']
             if not _is_blacklisted(contest)
-            and rating_cache.is_newly_finished_without_rating_changes(contest)
+               and rating_cache.is_newly_finished_without_rating_changes(contest)
         ]
 
         to_monitor = running_contests + finished_contests
@@ -579,51 +583,83 @@ class RanklistCache:
         for contest_id, ranklist in ranklist_by_contest.items():
             self.ranklist_by_contest[contest_id] = ranklist
 
-    async def generate_ranklist(self, contest_id, *, fetch_changes=False, predict_changes=False):
-        assert fetch_changes ^ predict_changes
-
+    @staticmethod
+    async def _get_contest_details(contest_id, show_unofficial):
         contest, problems, standings = await cf.contest.standings(contest_id=contest_id,
-                                                                  show_unofficial=True)
-        now = time.time()
+                                                                  show_unofficial=show_unofficial)
 
         # Exclude PRACTICE and MANAGER
         standings = [row for row in standings
                      if row.party.participantType in ('CONTESTANT', 'OUT_OF_COMPETITION', 'VIRTUAL')]
-        if fetch_changes:
-            # Fetch final rating changes from CF.
-            # For older contests.
-            is_rated = False
-            try:
-                changes = await cf.contest.ratingChanges(contest_id=contest_id)
-                # For contests intended to be rated but declared unrated, an empty list is returned.
-                is_rated = len(changes) > 0
-            except cf.RatingChangesUnavailableError:
-                pass
+
+        return contest, problems, standings
+
+    # Fetch final rating changes from CF.
+    # For older contests.
+    async def _get_ranklist_with_fetched_changes(self, contest_id, show_unofficial):
+        contest, problems, standings = await self._get_contest_details(contest_id, show_unofficial)
+        now = time.time()
+
+        is_rated = False
+        try:
+            changes = await cf.contest.ratingChanges(contest_id=contest_id)
+            # For contests intended to be rated but declared unrated, an empty list is returned.
+            is_rated = len(changes) > 0
+        except cf.RatingChangesUnavailableError:
+            pass
+
+        ranklist = None
+        if is_rated:
             ranklist = Ranklist(contest, problems, standings, now, is_rated=is_rated)
-            if is_rated:
-                delta_by_handle = {change.handle: change.newRating - change.oldRating
-                                   for change in changes}
-                ranklist.set_deltas(delta_by_handle)
-        elif predict_changes:
-            # Rating changes have not been applied yet, predict rating changes.
-            # For running/recent contests.
+            delta_by_handle = {change.handle: change.newRating - change.oldRating
+                               for change in changes}
+            ranklist.set_deltas(delta_by_handle)
+
+        return ranklist
+
+    # Rating changes have not been applied yet, predict rating changes.
+    # For running/recent/unrated contests.
+    async def _get_ranklist_with_predicted_changes(self, contest_id, show_unofficial):
+        contest, problems, standings = await self._get_contest_details(contest_id, show_unofficial)
+        now = time.time()
+
+        standings_official = None
+        if not show_unofficial:
+            standings_official = standings
+        else:
             _, _, standings_official = await cf.contest.standings(contest_id=contest_id)
 
-            has_teams = any(row.party.teamId is not None for row in standings_official)
-            if cf_common.is_nonstandard_contest(contest) or has_teams:
-                # The contest is not rated
-                ranklist = Ranklist(contest, problems, standings, now, is_rated=False)
-            else:
-                current_rating = await CacheSystem.getUsersEffectiveRating(activeOnly=False)
-                current_rating = {row.party.members[0].handle: current_rating.get(row.party.members[0].handle, 1500)
-                                  for row in standings_official}
-                if 'Educational' in contest.name:
-                    # For some reason educational contests return all contestants in ranklist even
-                    # when unofficial contestants are not requested.
-                    current_rating = {handle: rating
-                                      for handle, rating in current_rating.items() if rating < 2100}
-                ranklist = Ranklist(contest, problems, standings, now, is_rated=True)
-                ranklist.predict(current_rating)
+        has_teams = any(row.party.teamId is not None for row in standings_official)
+        if cf_common.is_nonstandard_contest(contest) or has_teams:
+            # The contest is not traditionally rated
+            ranklist = Ranklist(contest, problems, standings, now, is_rated=False)
+        else:
+            current_rating = await CacheSystem.getUsersEffectiveRating(activeOnly=False)
+            current_rating = {row.party.members[0].handle: current_rating.get(row.party.members[0].handle, 1500)
+                              for row in standings_official}
+            if 'Educational' in contest.name:
+                # For some reason educational contests return all contestants in ranklist even
+                # when unofficial contestants are not requested.
+                current_rating = {handle: rating
+                                  for handle, rating in current_rating.items() if rating < 2100}
+            ranklist = Ranklist(contest, problems, standings, now, is_rated=True)
+            ranklist.predict(current_rating)
+        return ranklist
+
+    async def generate_ranklist(self, contest_id, *, fetch_changes=False, predict_changes=False, show_unofficial=True):
+        assert fetch_changes ^ predict_changes
+
+        ranklist = None
+        if fetch_changes:
+            ranklist = await self._get_ranklist_with_fetched_changes(contest_id, show_unofficial)
+        if ranklist is None:
+            # Either predict_changes was true or fetching rating changes failed
+            ranklist = await self._get_ranklist_with_predicted_changes(contest_id, show_unofficial)
+
+        # for some reason Educational contests also have div1 peeps in the official standings.
+        # hence we need to manually weed them out
+        if not show_unofficial and 'Educational' in ranklist.contest.name:
+            ranklist.fix_rated_standings()
 
         return ranklist
 
@@ -634,20 +670,20 @@ class RanklistCache:
         # Exclude PRACTICE, MANAGER and OUR_OF_COMPETITION
         standings = [row for row in standings
                      if row.party.participantType == 'CONTESTANT' or
-                        row.party.members[0].handle in handles]
+                     row.party.members[0].handle in handles]
         standings.sort(key=lambda row: row.rank)
         standings = [row._replace(rank=i + 1) for i, row in enumerate(standings)]
         now = time.time()
         rating_changes = await cf.contest.ratingChanges(contest_id=contest_id)
-        current_official_rating = {rating_change.handle : rating_change.oldRating
-                                    for rating_change in rating_changes}
+        current_official_rating = {rating_change.handle: rating_change.oldRating
+                                   for rating_change in rating_changes}
 
         # TODO: assert that none of the given handles are in the official standings.
         handles = [row.party.members[0].handle for row in standings
                    if row.party.members[0].handle in handles and
-                      row.party.participantType == 'VIRTUAL']
+                   row.party.participantType == 'VIRTUAL']
         current_vc_rating = {handle: cf_common.user_db.get_vc_rating(handle_to_member_id.get(handle))
-                                for handle in handles}
+                             for handle in handles}
         ranklist = Ranklist(contest, problems, standings, now, is_rated=True)
         delta_by_handle = {}
         for handle in handles:
@@ -695,6 +731,5 @@ class CacheSystem:
         """
         ratedList = await cf.user.ratedList(activeOnly=activeOnly)
         users_effective_rating_dict = {user.handle: user.effective_rating
-                                  for user in ratedList}
+                                       for user in ratedList}
         return users_effective_rating_dict
-

--- a/tle/util/cache_system2.py
+++ b/tle/util/cache_system2.py
@@ -659,7 +659,7 @@ class RanklistCache:
         # for some reason Educational contests also have div1 peeps in the official standings.
         # hence we need to manually weed them out
         if not show_unofficial and 'Educational' in ranklist.contest.name:
-            ranklist.fix_rated_standings()
+            ranklist.remove_unofficial_contestants()
 
         return ranklist
 

--- a/tle/util/codeforces_common.py
+++ b/tle/util/codeforces_common.py
@@ -100,7 +100,7 @@ def is_contest_writer(contest_id, handle):
 
 _NONSTANDARD_CONTEST_INDICATORS = [
     'wild', 'fools', 'unrated', 'surprise', 'unknown', 'friday', 'q#', 'testing',
-    'marathon', 'kotlin', 'onsite', 'experimental', 'abbyy']
+    'marathon', 'kotlin', 'onsite', 'experimental', 'abbyy', 'icpc']
 
 
 def is_nonstandard_contest(contest):

--- a/tle/util/handledict.py
+++ b/tle/util/handledict.py
@@ -2,13 +2,14 @@
     A case insensitive dictionay with bare minimum functions required for handling usernames.
 """
 
+
 class HandleDict:
     def __init__(self):
         self._store = {}
 
     @staticmethod
     def _getlower(key):
-        return key.lower() if type(key)==str else key
+        return key.lower() if type(key) == str else key
 
     def __setitem__(self, key, value):
         # Use the lowercased key for lookups, but store the actual


### PR DESCRIPTION
1. Ranklist can now show official rated participants in ranklist (for eg : show contestants with < 2100 rating in a div2/hide virtual contestants in a div1)
2. Ranklist will fallback to predicted rating changes if fetched rating changes are not available
3. Remove predicted rating changes for events with "icpc" in the name (these are supposed to represent icpc mirrors or optimization contests)
4. Minor refactorings