### PR TITLE
Change docker image to ubuntu 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 USER root
 WORKDIR /TLE
 


### PR DESCRIPTION
Problem: Ubuntu 18.04 has problem with `cannot import name 'porcelain' from 'dulwich'`

Solution: Update to ubuntu 20.04

# Ubuntu 18.04

```sh
❯ docker build .
DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            Install the buildx component to build images with BuildKit:
            https://docs.docker.com/go/buildx/

Sending build context to Docker daemon  1.993MB
Step 1/12 : FROM ubuntu:18.04
 ---> f9a80a55f492
Step 2/12 : USER root
 ---> Using cache
 ---> 56b653d11aed
Step 3/12 : WORKDIR /TLE
 ---> Using cache
 ---> 1b102d46a40e
Step 4/12 : RUN apt-get update
 ---> Using cache
 ---> 76ebe830ff26
Step 5/12 : RUN apt-get install -y git apt-utils sqlite3
 ---> Using cache
 ---> 96a41a544b12
Step 6/12 : RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y libcairo2-dev libgirepository1.0-dev libpango1.0-dev pkg-config python3-dev gir1.2-pango-1.0 python3.8-venv libpython3.8-dev libjpeg-dev zlib1g-dev python3-pip
 ---> Using cache
 ---> fe8cab409891
Step 7/12 : RUN python3.8 -m pip install poetry
 ---> Using cache
 ---> 0773d5d85277
Step 8/12 : COPY ./poetry.lock ./poetry.lock
 ---> Using cache
 ---> d0a178db326a
Step 9/12 : COPY ./pyproject.toml ./pyproject.toml
 ---> Using cache
 ---> 729559139fda
Step 10/12 : RUN python3.8 -m poetry install
 ---> Running in 95a8b933f177
Creating virtualenv tle-Yc31TYj5-py3.8 in /root/.cache/pypoetry/virtualenvs

cannot import name 'porcelain' from 'dulwich' (unknown location)
The command '/bin/sh -c python3.8 -m poetry install' returned a non-zero code: 1
```

# Ubuntu 20.04
    
```sh
❯ docker build .
DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            Install the buildx component to build images with BuildKit:
            https://docs.docker.com/go/buildx/

Sending build context to Docker daemon  1.993MB
Step 1/12 : FROM ubuntu:20.04
 ---> 626a42b93d93
Step 2/12 : USER root
 ---> Using cache
 ---> b79ee3a4add4
Step 3/12 : WORKDIR /TLE
 ---> Using cache
 ---> 42716813241f
Step 4/12 : RUN apt-get update
 ---> Using cache
 ---> e99741925e15
Step 5/12 : RUN apt-get install -y git apt-utils sqlite3
 ---> Using cache
 ---> 786e1e24cfd8
Step 6/12 : RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y libcairo2-dev libgirepository1.0-dev libpango1.0-dev pkg-config python3-dev gir1.2-pango-1.0 python3.8-venv libpython3.8-dev libjpeg-dev zlib1g-dev python3-pip
 ---> Using cache
 ---> d7b333c1b89d
Step 7/12 : RUN python3.8 -m pip install poetry
 ---> Using cache
 ---> cbb796a1c236
Step 8/12 : COPY ./poetry.lock ./poetry.lock
 ---> Using cache
 ---> a9a7506fcc3d
Step 9/12 : COPY ./pyproject.toml ./pyproject.toml
 ---> Using cache
 ---> 84f96bb8e51b
Step 10/12 : RUN python3.8 -m poetry install
 ---> Using cache
 ---> cbf5986f6bf5
Step 11/12 : COPY . .
 ---> Using cache
 ---> a150cd2255d7
Step 12/12 : ENTRYPOINT ["/TLE/run.sh"]
 ---> Using cache
 ---> c69eb4a6432f
Successfully built c69eb4a6432f
```
