### PR TITLE
Add a way to install files using Pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ python3.7 -m pip install poetry
 python3.7 -m poetry install
 ```
 
+On some systems, Poetry is not able to install TLE's dependencies correctly. If you are unable to run `poetry install` without errors after completing the steps below, see the note at the end of the *final steps* section.
+
 ---
 
 #### Library dependencies
@@ -89,6 +91,14 @@ To start TLE just run:
 
 ```bash
 ./run.sh
+```
+
+On some systems, Poetry is unable to correctly install TLE's dependencies even after completing the above steps. In this case, using Pip to manage the dependencies instead may work. Note that Poetry still must be installed.
+
+To install dependencies in a virtual environment using Pip and start TLE, just run:
+
+```bash
+./run-pip.sh
 ```
 
 ### Notes

--- a/run-pip.sh
+++ b/run-pip.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Get to a predictable directory, the directory of this script
+cd "$(dirname "$0")"
+
+[ -e environment ] && . ./environment
+python3 -m venv .venv
+. .venv/bin/activate
+
+while true; do
+    git pull
+    poetry export --without-hashes > requirements.txt
+    python -m pip install --requirement requirements.txt
+    FONTCONFIG_FILE=$PWD/extra/fonts.conf python -m tle
+
+    (( $? != 42 )) && break
+
+    echo '==================================================================='
+    echo '=                       Restarting                                ='
+    echo '==================================================================='
+done


### PR DESCRIPTION
fixes #518 

This adds a new run script, run-pip.sh, which uses Pip instead of Poetry to install dependencies. It also modifies the README with appropriate instructions.