### PR TITLE
Update user_db_conn.py

### DIFF
--- a/tle/util/db/user_db_conn.py
+++ b/tle/util/db/user_db_conn.py
@@ -563,7 +563,7 @@ class UserDbConn:
 
     def get_reminder_settings(self, guild_id):
         query = """
-            SELECT channel_id, role_id, befor
+            SELECT channel_id, role_id, before
             FROM reminder
             WHERE guild_id = ?
         """


### PR DESCRIPTION
This PR fixes an sqlite3.OperationalError: no such column: befor in the TLE bot by correcting a typo in tle/util/db/user_db_conn.py.